### PR TITLE
Changing the verification URL sent in the email

### DIFF
--- a/api/mail/index.js
+++ b/api/mail/index.js
@@ -1,10 +1,10 @@
-"use strict";
+'use strict';
 
-var User = require("../models/User");
-var config = require("../../config");
-var mongoose = require("mongoose");
-var nev = require("email-verification")(mongoose);
-var bcrypt = require("bcryptjs");
+var User = require('../models/User');
+var config = require('../../config');
+var mongoose = require('mongoose');
+var nev = require('email-verification')(mongoose);
+var bcrypt = require('bcryptjs');
 
 module.exports = function(locale) {
   var myHasher = function(password, tempUserData, insertTempUser, callback) {
@@ -17,54 +17,54 @@ module.exports = function(locale) {
 
   var subject, html, text;
   switch (locale) {
-    case "en":
-      subject = "Cboard - Please confirm account";
+    case 'en':
+      subject = 'Cboard - Please confirm account';
       (html =
-        "Thanks for signup to Cboard!<br>Click the following link to confirm your account:</p><p>${URL}</p><br>Thanks,<br>The Cboard team"),
+        'Thanks for signup to Cboard!<br>Click the following link to confirm your account:</p><p>${URL}</p><br>Thanks,<br>The Cboard team'),
         (text =
-          "Thanks for signup to Cboard!. Please confirm your account by clicking the following link: ${URL}");
+          'Thanks for signup to Cboard!. Please confirm your account by clicking the following link: ${URL}');
       break;
-    case "es":
-      (subject = "Por favor, confirma tu cuenta"),
+    case 'es':
+      (subject = 'Por favor, confirma tu cuenta'),
         (html =
-          "Pulsa el enlace siguiente para confirmar tu cuenta:</p><p>${URL}</p>"),
+          'Pulsa el enlace siguiente para confirmar tu cuenta:</p><p>${URL}</p>'),
         (text =
-          "Por favor, confirma tu cuenta pulsando el enlace siguiente: ${URL}");
+          'Por favor, confirma tu cuenta pulsando el enlace siguiente: ${URL}');
       break;
     default:
-      subject = "Cboard - Please confirm account";
+      subject = 'Cboard - Please confirm account';
       (html =
-        "Thanks for signup to Cboard!<br>Click the following link to confirm your account:</p><p>${URL}</p><br>Thanks,<br>The Cboard team"),
+        'Thanks for signup to Cboard!<br>Click the following link to confirm your account:</p><p>${URL}</p><br>Thanks,<br>The Cboard team'),
         (text =
-          "Thanks for signup to Cboard!. Please confirm your account by clicking the following link: ${URL}");
+          'Thanks for signup to Cboard!. Please confirm your account by clicking the following link: ${URL}');
   }
 
   nev.configure(
     {
-      verificationURL: "https://www.cboard.io/user_activate/${URL}",
+      verificationURL: 'https://app.cboard.io/activate/${URL}',
       URLLength: 16,
 
       // mongo-stuff
       persistentUserModel: User,
-      emailFieldName: "email",
-      passwordFieldName: "password",
-      URLFieldName: "GENERATED_VERIFYING_URL",
+      emailFieldName: 'email',
+      passwordFieldName: 'password',
+      URLFieldName: 'GENERATED_VERIFYING_URL',
       expirationTime: 86400, //1 day
 
       // emailing options
       transportOptions: config.emailTransport,
       verifyMailOptions: {
-        from: "Do Not Reply <cboard@cboard.io>",
+        from: 'Do Not Reply <cboard@cboard.io>',
         subject: subject,
         html: html,
         text: text
       },
       shouldSendConfirmation: true,
       confirmMailOptions: {
-        from: "Do Not Reply <cboard@cboard.io>",
-        subject: "Cboard - Successfully verified!",
-        html: "<p>Your account at Cboard has been successfully verified.</p>",
-        text: "Your account at Cboard has been successfully verified."
+        from: 'Do Not Reply <cboard@cboard.io>',
+        subject: 'Cboard - Successfully verified!',
+        html: '<p>Your account at Cboard has been successfully verified.</p>',
+        text: 'Your account at Cboard has been successfully verified.'
       },
       hashingFunction: myHasher
     },
@@ -73,7 +73,7 @@ module.exports = function(locale) {
         console.log(err);
         return;
       }
-      console.log("configured: " + (typeof options === "object"));
+      console.log('configured: ' + (typeof options === 'object'));
     }
   );
 
@@ -83,7 +83,7 @@ module.exports = function(locale) {
       return;
     }
     console.log(
-      "generated temp user model: " + (typeof tempUserModel === "function")
+      'generated temp user model: ' + (typeof tempUserModel === 'function')
     );
   });
 


### PR DESCRIPTION
The app is now running on https://app.cboard.io and the route to activate an account is `/activate/:url`.

PS: My only change was on line 44, blame Prettier for the other changes. :stuck_out_tongue_closed_eyes: 