### PR TITLE
Add basic logger middleware for HTTP requests

### DIFF
--- a/app.js
+++ b/app.js
@@ -17,6 +17,7 @@ const MongoStore = require('connect-mongo')(session);
 const User = require('./api/models/User');
 const Facebook = require('./api/passport/facebook');
 const Google = require('./api/passport/google');
+const morgan = require('morgan');
 
 const config = require('./config');
 
@@ -25,6 +26,11 @@ const app = express();
 swaggerTools.initializeMiddleware(swaggerConfig, async function(middleware) {
   //Serves the Swagger UI on /docs
   app.use(cors());
+
+  // Log HTTP requests. The `dev` format looks like this:
+  // :method :url :status :response-time ms - :res[content-length]
+  app.use(morgan('dev'));
+
   app.use(bodyParser.json({ limit: '10mb' }));
   app.use(bodyParser.urlencoded({ extended: true, limit: '10mb' }));
   app.use(middleware.swaggerMetadata()); // needs to go BEFORE swaggerSecurity

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "jsonwebtoken": "^8.5.1",
     "moment": "2.24.0",
     "mongoose": "4.9.9",
+    "morgan": "^1.10.0",
     "ms": "^2.1.2",
     "nodemailer": "^6.4.2",
     "passport": "^0.4.1",


### PR DESCRIPTION
This PR adds a basic [`morgan`](https://github.com/expressjs/morgan) logger middleware to make debugging easier:

```
:method :url :status :response-time ms - :res[content-length]
```

```
POST /user/login 200 68.075 ms - 1243
GET /board/5ef5612576c3cd29d35a212b 200 2.075 ms - 433
GET /board/byemail/me@example.com?page=1&limit=100&offset=0 304 9.768 ms - -
```

For now, we don't log the request and response bodies, but it can be done with [`morgan-body`](https://github.com/sirrodgepodge/morgan-body). If we go this route, we'll need to make sure we don't log sensitive information like passwords.