### PR TITLE
Fix vulnerability with updateUser route

### DIFF
--- a/api/controllers/user.js
+++ b/api/controllers/user.js
@@ -246,6 +246,7 @@ const UPDATEABLE_FIELDS = [
   'email',
   'name',
   'birthdate',
+  'locale',
 ]
 
 function updateUser(req, res) {

--- a/api/controllers/user.js
+++ b/api/controllers/user.js
@@ -242,6 +242,12 @@ async function getUser(req, res) {
   }
 }
 
+const UPDATEABLE_FIELDS = [
+  'email',
+  'name',
+  'birthdate',
+]
+
 function updateUser(req, res) {
   const id = req.swagger.params.id.value;
   User.findById(id)
@@ -260,7 +266,9 @@ function updateUser(req, res) {
         });
       }
       for (let key in req.body) {
-        user[key] = req.body[key];
+        if (UPDATEABLE_FIELDS.includes(key)) {
+          user[key] = req.body[key];
+        }
       }
       user.save(function(err, user) {
         if (err) {

--- a/api/controllers/user.js
+++ b/api/controllers/user.js
@@ -250,6 +250,13 @@ const UPDATEABLE_FIELDS = [
 
 function updateUser(req, res) {
   const id = req.swagger.params.id.value;
+
+  if (!req.user.isAdmin && req.auth.id !== id) {
+    return res.status(403).json({
+      message: 'Only admins can update another user.'
+    })
+  }
+
   User.findById(id)
     .populate('communicators')
     .populate('boards')

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -107,6 +107,10 @@ userSchema.virtual('boards', {
   foreignField: 'email'
 });
 
+userSchema.virtual('isAdmin').get(function() {
+  return this.role === 'admin';
+});
+
 const validatePresenceOf = value => value && value.length;
 
 /**

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -798,7 +798,7 @@ paths:
           in: body
           required: true
           schema:
-            $ref: "#/definitions/User"
+            $ref: "#/definitions/UserUpdate"
       responses:
         "200":
           description: Success
@@ -943,6 +943,23 @@ definitions:
       locale:
         type: string
         enum:  &APP_LANGS ['ar-SA','bn-BD','cs-CZ','da-DK','de-DE','el-GR','en-US','en-GB','es-ES','fi-FI','fr-FR','he-IL','hi-IN','hu-HU','id-ID','it-IT','ja-JP','km-KH','ko-KR','ne-NP','nl-NL','no-NO','pl-PL','pt-BR','pt-PT','ro-RO','ru-RU','si-LK','sk-SK','sv-SE','th-TH','tr-TR','uk-UA','vi-VN','zh-CN','zu-ZA']
+  UserUpdate:
+    type: object
+    properties:
+      name:
+        type: string
+        example: Alice
+      email:
+        type: string
+        format: email
+        example: alice@example.com
+      birthdate:
+        type: string
+        format: date
+        example: 2001-10-17
+      locale:
+        type: string
+        enum:  *APP_LANGS
   Translate:
       type: object
       required:

--- a/test/controllers/board.js
+++ b/test/controllers/board.js
@@ -18,13 +18,9 @@ describe('Board API calls', function () {
   var authToken;
   var boardId;
 
-  before(async function (done) {
-    this.timeout(5000); //to await the email server process
-    helper.prepareUser(server)
-      .then(token => {
-        authToken = token;
-        done();
-      });
+  before(async function() {
+    const res = await helper.prepareUser(server);
+    authToken = res.token;
   });
 
   it('it should POST a board', function (done) {

--- a/test/controllers/user.js
+++ b/test/controllers/user.js
@@ -164,9 +164,14 @@ describe('User API calls', function () {
       });
 
       const update = {
+        // Updateable.
+        email: 'alice@example.com',
+        name: 'Alice',
+        birthdate: '2001-10-17',
+        locale: 'klingon',
+
+        // Not updateable.
         role: 'foobar',
-        name: 'martin',
-        email: 'martin@example.com',
         password: uuid.v4(),
       };
 
@@ -176,10 +181,13 @@ describe('User API calls', function () {
         .set('Authorization', `Bearer ${user.token}`)
         .expect(200);
 
-      expect(res.body.role).to.equal('user');
-      expect(res.body.password).not.to.equal(update.password);
       expect(res.body.email).to.equal(update.email);
       expect(res.body.name).to.equal(update.name);
+      expect(res.body.birthdate).to.contain(update.birthdate);
+      expect(res.body.locale).to.equal(update.locale);
+
+      expect(res.body.role).to.equal('user');
+      expect(res.body.password).not.to.equal(update.password);
     });
   });
 

--- a/test/controllers/user.js
+++ b/test/controllers/user.js
@@ -16,11 +16,8 @@ describe('User API calls', function () {
   let url;
   let userid;
 
-  before(async function (done) {
-    helper.deleteMochaUser(server).then((token) => {
-      authToken = token;
-      done();
-    });
+  before(async function() {
+    await helper.deleteMochaUser();
   });
 
   it('it should to create a new temporary user', function (done) {

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,5 +1,6 @@
 //Require the dev-dependencies
 const chai = require('chai');
+const { Express } = require('express');
 const mongoose = require('mongoose');
 const { token } = require('morgan');
 var request = require('supertest');
@@ -94,37 +95,57 @@ function prepareDb() {
   });
 }
 
-function prepareUser(server) {
-  var token;
-  var url;
-  return new Promise((resolve, reject) => {
-    request(server)
-      .post('/user')
-      .send(userData)
-      .expect(200)
-      .expect(function (res) {
-        url = res.body.url;
-      })
-      .end(function () {
-        request(server)
-          .post('/user/activate/' + url)
-          .send('')
-          .expect(200)
-          .end(function (err, res) {
-            userid = res.body.userid;
-            request(server)
-              .post('/user/login')
-              .send(userData)
-              .expect(200)
-              .expect(function (res) {
-                token = res.body.authToken;
-              })
-              .end(function () {
-                resolve(token, userid);
-              });
-          });
-      });
-  });
+function generateEmail() {
+  return `test${Date.now()}@example.com`;
+}
+
+/**
+ * A newly created test user.
+ * @typedef {Object} PrepareUserResponse
+ *
+ * @property {string} token
+ * @property {string} userId
+ */
+
+/**
+ * Create a test user and generate a token for them.
+ *
+ * @param {Express} server
+ *
+ * @param {Object} options
+ * @param {Object} options.overrides - Properties to overwrite the default
+ *   user data with.
+ *
+ * @returns {Promise<PrepareUserResponse>}
+ */
+async function prepareUser(server, overrides = {}) {
+  const data = {
+    ...userData,
+    ...overrides,
+  };
+
+  const createUser = await request(server)
+    .post('/user')
+    .send(data)
+    .expect(200);
+
+  const activationUrl = createUser.body.url;
+
+  const activateUser = await request(server)
+    .post(`/user/activate/${activationUrl}`)
+    .send('')
+    .expect(200);
+
+  const userId = activateUser.body.userid;
+
+  const login = await request(server)
+    .post('/user/login')
+    .send(data)
+    .expect(200);
+
+  const token = login.body.authToken;
+
+  return { token, userId };
 }
 
 async function deleteMochaUser() {
@@ -141,4 +162,5 @@ module.exports = {
   boardData,
   userData,
   userForgotPassword,
+  generateEmail: generateEmail,
 };

--- a/test/helper.js
+++ b/test/helper.js
@@ -127,37 +127,8 @@ function prepareUser(server) {
   });
 }
 
-function deleteMochaUser(server) {
-  let authToken;
-  return new Promise((resolve, reject) => {
-    User.findOne({ email: userData.email }, function (err, user) {
-      userid = user._id;
-      request(server)
-        .post('/user/login')
-        .send(userData)
-        .expect(200)
-        .expect(function (res) {
-          authToken = res.body.authToken;
-        })
-        .end(function () {
-          request(server)
-            .put('/user/' + userid)
-            .set('Authorization', 'Bearer ' + authToken)
-            .send({ role: 'admin' })
-            .end(function () {
-              request(server)
-                .del('/user/' + userid)
-                .set('Authorization', 'Bearer ' + authToken)
-                .set('Accept', 'application/json')
-                .expect('Content-Type', /json/)
-                .expect(200)
-                .end(function () {
-                  resolve();
-                });
-            });
-        });
-    });
-  });
+async function deleteMochaUser() {
+  return User.deleteOne({ email: userData.email });
 }
 
 module.exports = {


### PR DESCRIPTION
This PR fixes a critical vulnerability with the `updateRoute` that allows non-admin users to update _any_ user and _any_ field. It also simplifies some of the test helpers related to the creation and deletion of test users, and updates part of the tests to start using the `await` keyword instead of the `done` callback.

Close #136