### PR TITLE
Restrict access to /byemail routes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,11 +31,10 @@ jobs:
             -in  google-auth.json.cipher \
             -out google-auth.json \
             -k $KEY
-      - run: mkdir ~/junit
       # run tests
       - run: 
           name: Run Unitests
-          command: MOCHA_FILE=~/junit/test-results.xml ./node_modules/.bin/mocha test --recursive --reporter mocha-junit-reporter --exit
+          command: MOCHA_FILE=~/junit/test-results.xml npm test
           when: always
       - store_test_results:
           path: ~/junit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,9 +35,7 @@ jobs:
       # run tests
       - run: 
           name: Run Unitests
-          command: npm test
-          environment:
-            MOCHA_FILE: ~/junit/test-results.xml
+          command: MOCHA_FILE=~/junit/test-results.xml ./node_modules/.bin/mocha test --recursive --reporter mocha-junit-reporter --exit
           when: always
       - store_test_results:
           path: ~/junit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
       # run tests
       - run: 
           name: Run Unitests
-          command: ./node_modules/.bin/mocha test --recursive --reporter  mocha-junit-reporter
+          command: npm test
           environment:
             MOCHA_FILE: ~/junit/test-results.xml
           when: always

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ config/env/production.js
 *.njsproj.*
 *.sln
 /.vs
+
+test-results.xml

--- a/api/controllers/board.js
+++ b/api/controllers/board.js
@@ -41,8 +41,16 @@ async function listBoard(req, res) {
 }
 
 async function getBoardsEmail(req, res) {
-  const { search = '' } = req.query;
   const email = req.swagger.params.email.value;
+
+  if (!req.user.isAdmin && req.user.email !== email) {
+    return res.status(403).json({
+      message: "You are not authorized to get this user's boards."
+    });
+  }
+
+  const { search = '' } = req.query;
+
   const searchFields = ['name', 'author'];
   const query =
     search && search.length ? getORQuery(searchFields, search, true) : {};

--- a/api/controllers/communicator.js
+++ b/api/controllers/communicator.js
@@ -51,6 +51,13 @@ async function listCommunicators(req, res) {
 
 async function getCommunicatorsEmail(req, res) {
   const email = req.swagger.params.email.value;
+
+  if (!req.user.isAdmin && req.user.email !== email) {
+    return res.status(403).json({
+      message: "You are not authorized to get this user's communicators."
+    });
+  }
+
   const { search = '' } = req.query;
 
   const searchFields = ['name', 'author', 'description'];

--- a/api/controllers/user.js
+++ b/api/controllers/user.js
@@ -254,7 +254,7 @@ function updateUser(req, res) {
 
   if (!req.user.isAdmin && req.auth.id !== id) {
     return res.status(403).json({
-      message: 'Only admins can update another user.'
+      message: 'You are not authorized to update this user.'
     })
   }
 

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   "scripts": {
     "dev": "nodemon app.js",
     "start": "node app.js",
-    "test": "NODE_ENV=test swagger project test",
+    "test": "NODE_ENV=test mocha test --recursive --reporter mocha-junit-reporter --exit",
     "precommit": "lint-staged",
     "snyk-protect": "snyk protect",
     "prepare": "npm run snyk-protect"

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   "scripts": {
     "dev": "nodemon app.js",
     "start": "node app.js",
-    "test": "swagger project test",
+    "test": "NODE_ENV=test swagger project test",
     "precommit": "lint-staged",
     "snyk-protect": "snyk protect",
     "prepare": "npm run snyk-protect"

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   "scripts": {
     "dev": "nodemon app.js",
     "start": "node app.js",
-    "test": "NODE_ENV=test mocha test --recursive --reporter mocha-junit-reporter --exit",
+    "test": "NODE_ENV=test swagger project test",
     "precommit": "lint-staged",
     "snyk-protect": "snyk protect",
     "prepare": "npm run snyk-protect"

--- a/test/controllers/communicator.js
+++ b/test/controllers/communicator.js
@@ -1,0 +1,46 @@
+const request = require('supertest');
+const server = require('../../app');
+const helper = require('../helper');
+
+describe('Communicator API calls', function () {
+  describe('GET /communicator/byemail/:email', function() {
+    it("only allows an admin to get another user's communicators", async function() {
+      const adminEmail = helper.generateEmail();
+      const admin = await helper.prepareUser(server, {
+        role: 'admin',
+        email: adminEmail,
+      });
+
+      const userEmail = helper.generateEmail();
+      const user = await helper.prepareUser(server, {
+        role: 'user',
+        email: userEmail,
+      });
+
+      // Try to get another user's communicators as a regular user.
+      // This should fail.
+      await request(server)
+        .get(`/communicator/byemail/${encodeURI(adminEmail)}`)
+        .set('Authorization', `Bearer ${user.token}`)
+        .expect({
+          message: "You are not authorized to get this user's communicators.",
+        })
+        .expect(403);
+
+      // Try to get another user's communicators as an admin user.
+      // This should succeed.
+      await request(server)
+        .get(`/communicator/byemail/${encodeURI(userEmail)}`)
+        .set('Authorization', `Bearer ${admin.token}`)
+        .expect(200);
+
+
+      // Try to get my own communicators as a regular user.
+      // This should succeed.
+      await request(server)
+        .get(`/communicator/byemail/${encodeURI(userEmail)}`)
+        .set('Authorization', `Bearer ${user.token}`)
+        .expect(200);
+    });
+  });
+});

--- a/test/controllers/user.js
+++ b/test/controllers/user.js
@@ -145,7 +145,7 @@ describe('User API calls', function () {
         .put(`/user/${admin.userId}`)
         .set('Authorization', `Bearer ${user.token}`)
         .expect({
-          message: 'Only admins can update another user.',
+          message: 'You are not authorized to update this user.',
         })
         .expect(403);
 

--- a/test/helper.js
+++ b/test/helper.js
@@ -6,6 +6,7 @@ const { token } = require('morgan');
 var request = require('supertest');
 const user = require('../api/controllers/user');
 const should = chai.should();
+const uuid = require('uuid');
 
 const User = require('../api/models/User');
 
@@ -96,7 +97,7 @@ function prepareDb() {
 }
 
 function generateEmail() {
-  return `test${Date.now()}@example.com`;
+  return `test.${uuid.v4()}@example.com`;
 }
 
 /**


### PR DESCRIPTION
This PR updates the `getCommunicatorsEmail` and `getBoardsEmail` routes to return a 403 if a non-admin user sends the wrong email address. There are no restrictions for admins. This is the first step towards updating the `Communicator` and `Board`  schemas to identify the owner by their id rather than their email address. See #140.