### PR TITLE
165 completion of skipped test suites

### DIFF
--- a/test/controllers/analytics.js
+++ b/test/controllers/analytics.js
@@ -1,8 +1,6 @@
 const request = require('supertest');
 const chai = require('chai');
 
-const User = require('../../api/models/User');
-
 const helper = require('../helper');
 
 //Parent block
@@ -17,7 +15,7 @@ describe('analytics API calls', function () {
 
   after(async function () {
     helper.prepareNodemailerMock(true);
-    await User.deleteMany({ name: 'cboard mocha test' });
+    helper.deleteMochaUsers();
   });
 
   describe('POST /analytics/batchGet', function () {

--- a/test/controllers/analytics.js
+++ b/test/controllers/analytics.js
@@ -15,7 +15,7 @@ describe('analytics API calls', function () {
 
   after(async function () {
     helper.prepareNodemailerMock(true);
-    helper.deleteMochaUsers();
+    await helper.deleteMochaUsers();
   });
 
   describe('POST /analytics/batchGet', function () {

--- a/test/controllers/analytics.js
+++ b/test/controllers/analytics.js
@@ -21,12 +21,12 @@ describe('analytics API calls', function () {
   });
 
   describe('POST /analytics/batchGet', function () {
-    before(async function(){
+    before(async function () {
       user = await helper.prepareUser(server, {
         role: 'user',
         email: helper.generateEmail(),
       });
-    })
+    });
 
     it('it should NOT return analytics User data without bearer.', async function () {
       await request(server)

--- a/test/controllers/analytics.js
+++ b/test/controllers/analytics.js
@@ -1,26 +1,33 @@
 const request = require('supertest');
 const chai = require('chai');
 
-const server = require('../../app');
+const User = require('../../api/models/User');
+
 const helper = require('../helper');
 
 //Parent block
-describe.skip('analytics API calls', function () {
+describe('analytics API calls', function () {
+  let server;
   let user;
 
   before(async function () {
-    await helper.deleteMochaUser();
-    user = await helper.prepareUser(server, {
-      role: 'user',
-      email: helper.userData.email,
-    });
+    helper.prepareNodemailerMock(); //enable mockery and replace nodemailer with nodemailerMock
+    server = require('../../app'); //register mocks before require the original dependency
   });
 
   after(async function () {
-    await helper.deleteMochaUser();
+    helper.prepareNodemailerMock(true);
+    await User.deleteMany({ name: 'cboard mocha test' });
   });
 
   describe('POST /analytics/batchGet', function () {
+    before(async function(){
+      user = await helper.prepareUser(server, {
+        role: 'user',
+        email: helper.generateEmail(),
+      });
+    })
+
     it('it should NOT return analytics User data without bearer.', async function () {
       await request(server)
         .post('/analytics/batchGet')

--- a/test/controllers/board.js
+++ b/test/controllers/board.js
@@ -8,7 +8,6 @@ var expect = require('chai').expect;
 const should = chai.should();
 const helper = require('../helper');
 
-const User = require('../../api/models/User');
 const Board = require('../../api/models/Board');
 
 //Parent block
@@ -31,7 +30,7 @@ describe('Board API calls', function () {
 
   after(async function () {
     helper.prepareNodemailerMock(true); //disable mockery
-    await User.deleteMany({ name: 'cboard mocha test' });
+    helper.deleteMochaUsers();
     await Board.deleteMany({ author: 'cboard mocha test' });
   });
 

--- a/test/controllers/board.js
+++ b/test/controllers/board.js
@@ -30,7 +30,7 @@ describe('Board API calls', function () {
 
   after(async function () {
     helper.prepareNodemailerMock(true); //disable mockery
-    helper.deleteMochaUsers();
+    await helper.deleteMochaUsers();
     await Board.deleteMany({ author: 'cboard mocha test' });
   });
 

--- a/test/controllers/communicator.js
+++ b/test/controllers/communicator.js
@@ -17,7 +17,7 @@ describe('Communicator API calls', function () {
 
   after(async function () {
     helper.prepareNodemailerMock(true);
-    helper.deleteMochaUsers();
+    await helper.deleteMochaUsers();
     await Communicator.deleteMany({ author: 'cboard mocha test' });
   });
 

--- a/test/controllers/communicator.js
+++ b/test/controllers/communicator.js
@@ -18,7 +18,7 @@ describe('Communicator API calls', function () {
   after(async function () {
     helper.prepareNodemailerMock(true);
     helper.deleteMochaUsers();
-    await Communicator.deleteMany({ author: "cboard mocha test" });
+    await Communicator.deleteMany({ author: 'cboard mocha test' });
   });
 
   beforeEach(async function () {

--- a/test/controllers/languages.js
+++ b/test/controllers/languages.js
@@ -1,11 +1,16 @@
 const request = require('supertest');
 const chai = require('chai');
 
-const server = require('../../app');
 const helper = require('../helper');
 
 //Parent block
 describe('Languages API calls', function () {
+  let server;
+
+  before(async function () {
+    server = require('../../app');
+  });
+
   describe('GET /languages', function () {
     it('it should return the full Language list.', async function () {
       const res = await request(server)

--- a/test/controllers/media.js
+++ b/test/controllers/media.js
@@ -23,12 +23,12 @@ describe('media API calls', function () {
   });
 
   describe('POST /media', function () {
-    before(async function(){
+    before(async function () {
       user = await helper.prepareUser(server, {
         role: 'user',
         email: helper.generateEmail(),
       });
-    })
+    });
 
     it('it should NOT post a media file without authToken.', async function () {
       const res = await request(server)

--- a/test/controllers/media.js
+++ b/test/controllers/media.js
@@ -17,7 +17,7 @@ describe('media API calls', function () {
 
   after(async function () {
     helper.prepareNodemailerMock(true);
-    helper.deleteMochaUsers();
+    await helper.deleteMochaUsers();
   });
 
   describe('POST /media', function () {

--- a/test/controllers/media.js
+++ b/test/controllers/media.js
@@ -1,8 +1,6 @@
 const request = require('supertest');
 const chai = require('chai');
 
-const User = require('../../api/models/User');
-
 const helper = require('../helper');
 
 const fs = require('fs');
@@ -19,7 +17,7 @@ describe('media API calls', function () {
 
   after(async function () {
     helper.prepareNodemailerMock(true);
-    await User.deleteMany({ name: 'cboard mocha test' });
+    helper.deleteMochaUsers();
   });
 
   describe('POST /media', function () {

--- a/test/controllers/media.js
+++ b/test/controllers/media.js
@@ -1,23 +1,35 @@
 const request = require('supertest');
 const chai = require('chai');
 
-const server = require('../../app');
+const User = require('../../api/models/User');
+
 const helper = require('../helper');
 
 const fs = require('fs');
 const { expect } = require('chai');
 
 //Parent block
-describe.skip('media API calls', function () {
-  var authToken;
+describe('media API calls', function () {
+  let server;
 
   before(async function () {
-    await helper.deleteMochaUser();
-    const res = await helper.prepareUser(server);
-    authToken = res.token;
+    helper.prepareNodemailerMock(); //enable mockery and replace nodemailer with nodemailerMock
+    server = require('../../app'); //register mocks before require the original dependency
+  });
+
+  after(async function () {
+    helper.prepareNodemailerMock(true);
+    await User.deleteMany({ name: 'cboard mocha test' });
   });
 
   describe('POST /media', function () {
+    before(async function(){
+      user = await helper.prepareUser(server, {
+        role: 'user',
+        email: helper.generateEmail(),
+      });
+    })
+
     it('it should NOT post a media file without authToken.', async function () {
       const res = await request(server)
         .post('/media')
@@ -42,7 +54,7 @@ describe.skip('media API calls', function () {
     it('it should post a media file.', async function () {
       const res = await request(server)
         .post('/media')
-        .set('Authorization', 'Bearer ' + authToken)
+        .set('Authorization', 'Bearer ' + user.token)
         .set('Accept', 'image/webp,*/*')
         .set(
           'Content-Disposition',

--- a/test/controllers/settings.js
+++ b/test/controllers/settings.js
@@ -65,7 +65,6 @@ describe('Settings API calls', function () {
         .set('Accept', 'application/json')
         .expect('Content-Type', /json/)
         .expect(200);
-      console.log(res.body);
     });
 
     it('it should Returns settings for current user', async function () {

--- a/test/controllers/settings.js
+++ b/test/controllers/settings.js
@@ -21,7 +21,7 @@ describe('Settings API calls', function () {
 
   after(async function () {
     helper.prepareNodemailerMock(true); //disable mockery
-    helper.deleteMochaUsers();
+    await helper.deleteMochaUsers();
   });
 
   describe('POST /settings', function () {

--- a/test/controllers/settings.js
+++ b/test/controllers/settings.js
@@ -16,7 +16,7 @@ describe('Settings API calls', function () {
     helper.userData.email = helper.generateEmail();
     user = await helper.prepareUser(server, {
       role: 'user',
-      email: helper.userData.email
+      email: helper.userData.email,
     });
   });
 
@@ -57,7 +57,7 @@ describe('Settings API calls', function () {
   });
 
   describe('GET /settings', function () {
-    before(async function(){
+    before(async function () {
       const res = await request(server)
         .post('/settings')
         .send(helper.settingsData)
@@ -65,7 +65,7 @@ describe('Settings API calls', function () {
         .set('Accept', 'application/json')
         .expect('Content-Type', /json/)
         .expect(200);
-      console.log(res.body);  
+      console.log(res.body);
     });
 
     it('it should Returns settings for current user', async function () {

--- a/test/controllers/settings.js
+++ b/test/controllers/settings.js
@@ -13,10 +13,9 @@ describe('Settings API calls', function () {
   before(async function () {
     helper.prepareNodemailerMock(); //enable mockery and replace nodemailer with nodemailerMock
     server = require('../../app'); //register mocks before require the original dependency
-    helper.userData.email = helper.generateEmail();
     user = await helper.prepareUser(server, {
       role: 'user',
-      email: helper.userData.email,
+      email: helper.generateEmail(),
     });
   });
 

--- a/test/controllers/translate.js
+++ b/test/controllers/translate.js
@@ -3,19 +3,26 @@ process.env.NODE_ENV = 'test';
 const request = require('supertest');
 const chai = require('chai');
 
-const server = require('../../app');
 const helper = require('../helper');
 
 //Parent block
 describe('Translate API calls', function () {
   let user;
+  let server;
 
   before(async function () {
-    await helper.deleteMochaUser();
+    helper.prepareNodemailerMock(); //enable mockery and replace nodemailer with nodemailerMock
+    server = require('../../app'); //register mocks before require the original dependency
+    helper.userData.email = helper.generateEmail();
     user = await helper.prepareUser(server, {
       role: 'user',
-      email: helper.userData.email,
+      email: helper.userData.email
     });
+  });
+
+  after(async function () {
+    helper.prepareNodemailerMock(true); //disable mockery
+    helper.deleteMochaUsers();
   });
 
   describe('POST /translate', function () {

--- a/test/controllers/translate.js
+++ b/test/controllers/translate.js
@@ -22,7 +22,7 @@ describe('Translate API calls', function () {
 
   after(async function () {
     helper.prepareNodemailerMock(true); //disable mockery
-    helper.deleteMochaUsers();
+    await helper.deleteMochaUsers();
   });
 
   describe('POST /translate', function () {

--- a/test/controllers/translate.js
+++ b/test/controllers/translate.js
@@ -16,7 +16,7 @@ describe('Translate API calls', function () {
     helper.userData.email = helper.generateEmail();
     user = await helper.prepareUser(server, {
       role: 'user',
-      email: helper.userData.email
+      email: helper.userData.email,
     });
   });
 

--- a/test/controllers/user.js
+++ b/test/controllers/user.js
@@ -14,14 +14,14 @@ const User = require('../../api/models/User');
 describe('User API calls', function () {
   let server;
 
-  before(function () {
+  before(async function () {
     helper.prepareNodemailerMock(); //enable mockery and replace nodemailer with nodemailerMock
     server = require('../../app'); //register mocks before require the original dependency
   });
 
   after(async function () {
     helper.prepareNodemailerMock(true); //disable mockery
-    helper.deleteMochaUsers();
+    await helper.deleteMochaUsers();
     await User.deleteMany({ name: 'testAlice' });
   });
 

--- a/test/controllers/user.js
+++ b/test/controllers/user.js
@@ -21,7 +21,7 @@ describe('User API calls', function () {
 
   after(async function () {
     helper.prepareNodemailerMock(true); //disable mockery
-    await User.deleteMany({ name: 'cboard mocha test' });
+    helper.deleteMochaUsers();
     await User.deleteMany({ name: 'testAlice' });
   });
 

--- a/test/helper.js
+++ b/test/helper.js
@@ -5,7 +5,6 @@ const mongoose = require('mongoose');
 const { token } = require('morgan');
 var request = require('supertest');
 const User = require('../api/models/User');
-const Communicator = require('../api/models/Communicator');
 const should = chai.should();
 
 /**helper nodemailer-mock
@@ -77,6 +76,10 @@ const verifyCommunicatorProperties = (body) => {
     'boards'
   );
 };
+
+/**
+ * Data Mocks to use on test
+ */
 
 const userData = {
   name: 'cboard mocha test',
@@ -152,6 +155,15 @@ const translateData = {
   to: 'zh-CN',
 };
 
+const analyticsReportData = [{
+  clientId: 'test.mocha',
+  dimension: 'nthDay',
+  metric: 'avgSessionDuration',
+  endDate: 'today',
+  mobileView: false,
+  startDate: '30daysago',
+}]
+
 const communicatorData = {
   id: 'root',
   name: 'home',
@@ -177,9 +189,14 @@ function prepareDb() {
   });
 }
 
-/*Test helpers */
+/*generate email to create new users*/
 function generateEmail() {
   return `test${Date.now()}@example.com`;
+}
+
+/*clean test users*/
+ async function deleteMochaUsers(){
+  await User.deleteMany({ name: 'cboard mocha test' });
 }
 
 /**
@@ -228,23 +245,6 @@ async function prepareUser(server, overrides = {}) {
   return { token, userId };
 }
 
-async function deleteMochaUser() {
-  if (await User.exists({ email: userData.email })) {
-    await User.deleteOne({ email: userData.email });
-  }
-  if (await User.exists({ email: adminData.email })) {
-    await User.deleteOne({ email: adminData.email });
-  }
-  return;
-}
-
-async function deleteMochaUserById(userid) {
-  if (await User.exists({ _id: userid })) {
-    await User.deleteOne({ _id: userid });
-  }
-  return;
-}
-
 /**
  * A newly created test Communicator.
  * @typedef {Object} createCommunicatorResponse
@@ -267,13 +267,6 @@ async function createCommunicator(server, userToken) {
     .send(communicatorData)
     .expect(200);
   return createCommunicator.body.id;
-}
-
-async function deleteCommunicatorById(communicatorid) {
-  if (await Communicator.exists({ _id: communicatorid })) {
-    await Communicator.deleteOne({ _id: communicatorid });
-  }
-  return;
 }
 
 /**
@@ -310,17 +303,16 @@ module.exports = {
   verifyCommunicatorProperties,
   prepareDb,
   prepareUser,
-  deleteMochaUser,
-  deleteMochaUserById,
+  deleteMochaUsers,
   createCommunicator,
-  deleteCommunicatorById,
   createMochaBoard,
   boardData,
   communicatorData,
   adminData,
   userData,
   userForgotPassword,
+  analyticsReportData,
   settingsData,
-  generateEmail: generateEmail,
   translateData,
+  generateEmail: generateEmail,
 };

--- a/test/helper.js
+++ b/test/helper.js
@@ -155,14 +155,16 @@ const translateData = {
   to: 'zh-CN',
 };
 
-const analyticsReportData = [{
-  clientId: 'test.mocha',
-  dimension: 'nthDay',
-  metric: 'avgSessionDuration',
-  endDate: 'today',
-  mobileView: false,
-  startDate: '30daysago',
-}]
+const analyticsReportData = [
+  {
+    clientId: 'test.mocha',
+    dimension: 'nthDay',
+    metric: 'avgSessionDuration',
+    endDate: 'today',
+    mobileView: false,
+    startDate: '30daysago',
+  },
+];
 
 const communicatorData = {
   id: 'root',
@@ -195,7 +197,7 @@ function generateEmail() {
 }
 
 /*clean test users*/
- async function deleteMochaUsers(){
+async function deleteMochaUsers() {
   await User.deleteMany({ name: 'cboard mocha test' });
 }
 

--- a/test/helper.js
+++ b/test/helper.js
@@ -27,6 +27,7 @@ function prepareNodemailerMock(isDisabling = 0) {
   }
 
   mockery.enable({
+    warnOnReplace: false,
     warnOnUnregistered: false,
   });
 


### PR DESCRIPTION
This PR 
-update the integrations tests to use properly the actual prepareuser() function when creates a user.
-mock the nodemailer to don't send emails during tests. (this give us faster feedback loop)
-restore analytics mock data to allow the analytic test to work.
-comment helper file to explains code. 

the user store-password test continues skipped until resolve #161 . I mean these tests gonna be different because de sensible data is not more sending on the response and the token is stored hashed in DB. 
Thanks, @sylvansson and @martinbedouret  for your help.
