### PR TITLE
Write tests for deleteBoard route bug

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
       # run tests
       - run: 
           name: Run Unitests
-          command: MOCHA_FILE=~/junit/test-results.xml npm test
+          command: MOCHA_FILE=~/junit/test-results.xml ./node_modules/.bin/mocha test --recursive --reporter mocha-junit-reporter --exit
           when: always
       - store_test_results:
           path: ~/junit

--- a/api/controllers/board.js
+++ b/api/controllers/board.js
@@ -15,6 +15,7 @@ module.exports = {
   getPublicBoards: getPublicBoards
 };
 
+// TODO: Use the caller's email instead of getting it from the body.
 function createBoard(req, res) {
   const board = new Board(req.body);
   board.lastEdited = moment().format();

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   "scripts": {
     "dev": "nodemon app.js",
     "start": "node app.js",
-    "test": "NODE_ENV=test mocha test --recursive --reporter mocha-junit-reporter --exit",
+    "test": "NODE_ENV=test swagger project test",
     "precommit": "lint-staged",
     "snyk-protect": "snyk protect",
     "prepare": "npm run snyk-protect"

--- a/test/controllers/board.js
+++ b/test/controllers/board.js
@@ -198,6 +198,58 @@ describe('Board API calls', function () {
         .expect('Content-Type', /json/)
         .expect(404);
     });
+
+    it.skip("returns a 404 if the caller is not an admin and doesn't own the board", async function () {
+      const email = helper.generateEmail();
+      const user1 = await helper.prepareUser(server, { email });
+      const user2 = await helper.prepareUser(server, {
+        // The user is not an admin, so they should only be able
+        // to delete their own boards.
+        role: 'user',
+        email: helper.generateEmail(),
+      });
+
+      const { body: { id: boardId } } = await request(server)
+        .post('/board')
+        .send({ ...helper.boardData, email })
+        .set('Authorization', `Bearer ${user1.token}`)
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200);
+
+      await request(server)
+        .del(`/board/${boardId}`)
+        .set('Authorization', `Bearer ${user2.token}`)
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(404);
+    });
+
+    it.skip("deletes the board if the caller is an admin but doesn't own the board", async function () {
+      const email = helper.generateEmail();
+      const user1 = await helper.prepareUser(server, { email });
+      const user2 = await helper.prepareUser(server, {
+        // The user is an admin, so they should be able to delete
+        // any board.
+        role: 'admin',
+        email: helper.generateEmail(),
+      });
+
+      const { body: { id: boardId } } = await request(server)
+        .post('/board')
+        .send({ ...helper.boardData, email })
+        .set('Authorization', `Bearer ${user1.token}`)
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200);
+
+      await request(server)
+        .del(`/board/${boardId}`)
+        .set('Authorization', `Bearer ${user2.token}`)
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200);
+    });
   });
 
   describe('GET /board/byemail/:email', function() {


### PR DESCRIPTION
This PR adds two (skipped) tests for the `deleteBoard` route bug described in #173. Whoever picks up the task will be able to easily test that their changes are working properly.