### PR TITLE
Dynamic callback for Google and Facebook login

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -5,7 +5,9 @@ const production = require('./env/production');
 
 const defaults = {
   host: process.env.HOST || 'mongodb',
-  port: process.env.PORT || 8100
+  port: process.env.PORT || 8100,
+  googleCallbackPath: 'login/google/callback',
+  facebookCallbackPath: 'login/facebook/callback'  
 };
 
 function getConfig() {


### PR DESCRIPTION
This PR solves the error during login through Google and Facebook on development. It configures the callbackURL on passport auth using req.header.referer
After merging this the environmental variable FACEBOOK_CALLBACK_URL and GOOGLE_CALLBACK_URL are no more needed