### PR TITLE
Facebook passport token for implement facebook login on Android devices 

### DIFF
--- a/api/passport/facebookToken.js
+++ b/api/passport/facebookToken.js
@@ -1,0 +1,30 @@
+const passport = require('passport');
+const FacebookTokenStrategy = require('passport-facebook-token');
+const config = require('../../config');
+const UserController = require('../controllers/user');
+
+const FBStrategy = {
+    clientID: process.env.FACEBOOK_APP_ID,
+    clientSecret: process.env.FACEBOOK_APP_SECRET,
+    fbGraphVersion: 'v3.0'
+  };
+
+passport.use(new FacebookTokenStrategy(FBStrategy, UserController.facebookLogin));
+
+const configureFacebookTokenStrategy = app => {
+    app.get(
+      '/login/facebooktoken/callback',
+      passport.authenticate('facebook-token', {
+        failureRedirect: '/',
+        session: false
+      }),
+      (req, res) => {
+        res.json(req.user);
+        console.log(req.user);
+      }
+    );
+};
+  
+module.exports = {
+    configureFacebookTokenStrategy
+};

--- a/app.js
+++ b/app.js
@@ -18,6 +18,7 @@ const User = require('./api/models/User');
 const Facebook = require('./api/passport/facebook');
 const Google = require('./api/passport/google');
 const GoogleToken = require('./api/passport/googleToken');
+const FacebookToken = require('./api/passport/facebookToken');
 const morgan = require('morgan');
 const config = require('./config');
 
@@ -97,6 +98,7 @@ swaggerTools.initializeMiddleware(swaggerConfig, async function (middleware) {
   Facebook.configureFacebookStrategy(app);
   Google.configureGoogleStrategy(app);
   GoogleToken.configureGoogleTokenStrategy(app);
+  FacebookToken.configureFacebookTokenStrategy(app);
   startServer(app);
 });
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "nodemailer": "^6.6.1",
     "passport": "^0.4.1",
     "passport-facebook": "^3.0.0",
+    "passport-facebook-token": "^4.0.0",
     "passport-google-oauth": "^2.0.0",
     "passport-google-token": "^0.1.2",
     "pem": "^1.14.4",


### PR DESCRIPTION
This PR uses the package:
 [Passport-FB-token](https://www.npmjs.com/package/passport-facebook-token)  Passport strategy for authenticating with Facebook access tokens using the OAuth 2.0 API.
Issue: [#862](https://github.com/cboard-org/cboard/issues/862#issue-828624952)