### PR TITLE
set Cache-Control when store new media on Azure blob storage

### DIFF
--- a/api/helpers/blob.js
+++ b/api/helpers/blob.js
@@ -33,8 +33,10 @@ async function createBlockBlobFromText(
 
   const options = {};
   if (mimetype && mimetype.length) {
+    const cacheMaxAgeInSeconds = 31536000;
     options.contentSettings = {
-      contentType: mimetype
+      contentType: mimetype,
+      cacheControl: `max-age=${cacheMaxAgeInSeconds}`
     };
   }
 


### PR DESCRIPTION
this change set the Cache-control header to the blob stored on azure blob storage. Causing that cboard app could store users' uploaded images on the cache to use after when devices are offline.   