### PR TITLE
fix "header already sent" error when sending verification email

### DIFF
--- a/api/controllers/user.js
+++ b/api/controllers/user.js
@@ -80,13 +80,13 @@ async function createUser(req, res) {
             message: 'ERROR: sending verification email FAILED ' + info
           });
         }
-      });
 
-      return res.status(200).json({
-        success: 1,
-        url: URL,
-        message:
-          'An email has been sent to you. Please check it to verify your account.'
+        return res.status(200).json({
+          success: 1,
+          url: URL,
+          message:
+              'An email has been sent to you. Please check it to verify your account.'
+        });
       });
 
       // user already exists in temporary collection!


### PR DESCRIPTION
Since the successful response is returned outside the callback, even when something went wrong, a successful response was sent. It was also hiding the actual error behind a header error.