### PR TITLE
Feature/add isOnTryPeriod on user

### DIFF
--- a/api/controllers/user.js
+++ b/api/controllers/user.js
@@ -114,7 +114,7 @@ async function passportLogin(ip, type, accessToken, refreshToken, profile, done)
       user = await createOrUpdateUser(accessToken, profile, type);
     }
 
-    const isOnTryPeriod = (user.createdAt);
+    const isOnTryPeriod = isUserOnTryPeriod(user.createdAt);
 
     if (!user.location || !user.location.countryisUserOnTryPeriod)
       try {

--- a/api/controllers/user.js
+++ b/api/controllers/user.js
@@ -343,6 +343,8 @@ function loginUser(req, res) {
         id: userId
       });
 
+      const isOnTryPeriod = isUserOnTryPeriod(user.createdAt);
+      
       if (!user.location || !user.location.country)
         try {
           await updateUserLocation(req.ip, user);
@@ -356,7 +358,8 @@ function loginUser(req, res) {
         ...user.toJSON(),
         settings,
         birthdate: moment(user.birthdate).format('YYYY-MM-DD'),
-        authToken: tokenString
+        authToken: tokenString,
+        isOnTryPeriod
       };
       return res.status(200).json(response);
     }

--- a/api/controllers/user.js
+++ b/api/controllers/user.js
@@ -363,6 +363,16 @@ function loginUser(req, res) {
   });
 }
 
+function isUserOnTryPeriod(createdAt){
+  const createdAtDate = new Date(createdAt);
+  const actualTime = new Date();
+  const DAYS_TO_TRY = 30;
+  const tryLimit = createdAtDate.setDate(createdAtDate.getDate() + DAYS_TO_TRY);
+  if(createdAt === null) return false;
+  if(actualTime >= tryLimit ) return false;
+  return true;
+}
+
 async function updateUserLocation(ip, user) {
   if ((!user.location || !user.location.country) && !isLocalIp(ip)) {
     try {

--- a/api/controllers/user.js
+++ b/api/controllers/user.js
@@ -248,9 +248,11 @@ async function getUser(req, res) {
     }
 
     const settings = await getSettings(user);
+    const isOnTryPeriod = isUserOnTryPeriod(user.createdAt);
     const response = {
       ...user.toJSON(),
-      settings
+      settings,
+      isOnTryPeriod
     };
 
     return res.status(200).json(response);

--- a/api/controllers/user.js
+++ b/api/controllers/user.js
@@ -371,11 +371,11 @@ function loginUser(req, res) {
 
 function isUserOnTryPeriod(createdAt){
   const createdAtDate = new Date(createdAt);
-  const actualTime = new Date();
+  const actualDate = new Date();
   const DAYS_TO_TRY = 30;
-  const tryLimit = createdAtDate.setDate(createdAtDate.getDate() + DAYS_TO_TRY);
+  const tryLimitDate = createdAtDate.setDate(createdAtDate.getDate() + DAYS_TO_TRY);
   if(createdAt === null) return false;
-  if(actualTime >= tryLimit ) return false;
+  if(actualDate >= tryLimitDate ) return false;
   return true;
 }
 

--- a/api/controllers/user.js
+++ b/api/controllers/user.js
@@ -114,9 +114,9 @@ async function passportLogin(ip, type, accessToken, refreshToken, profile, done)
       user = await createOrUpdateUser(accessToken, profile, type);
     }
 
-    const isOnTryPeriod = isUserOnTryPeriod(user.createdAt);
+    const isOnTrialPeriod = isUserOnTrialPeriod(user.createdAt);
 
-    if (!user.location || !user.location.countryisUserOnTryPeriod)
+    if (!user.location || !user.location.countryisUserOnTrialPeriod)
       try {
         await updateUserLocation(ip, user);
       } catch (error) {
@@ -135,7 +135,7 @@ async function passportLogin(ip, type, accessToken, refreshToken, profile, done)
       ...user.toJSON(),
       settings,
       authToken: tokenString,
-      isOnTryPeriod
+      isOnTrialPeriod
     };
 
     done(null, response);
@@ -248,11 +248,11 @@ async function getUser(req, res) {
     }
 
     const settings = await getSettings(user);
-    const isOnTryPeriod = isUserOnTryPeriod(user.createdAt);
+    const isOnTrialPeriod = isUserOnTrialPeriod(user.createdAt);
     const response = {
       ...user.toJSON(),
       settings,
-      isOnTryPeriod
+      isOnTrialPeriod
     };
 
     return res.status(200).json(response);
@@ -348,7 +348,7 @@ function loginUser(req, res) {
         id: userId
       });
 
-      const isOnTryPeriod = isUserOnTryPeriod(user.createdAt);
+      const isOnTrialPeriod = isUserOnTrialPeriod(user.createdAt);
       
       if (!user.location || !user.location.country)
         try {
@@ -364,14 +364,14 @@ function loginUser(req, res) {
         settings,
         birthdate: moment(user.birthdate).format('YYYY-MM-DD'),
         authToken: tokenString,
-        isOnTryPeriod
+        isOnTrialPeriod
       };
       return res.status(200).json(response);
     }
   });
 }
 
-function isUserOnTryPeriod(createdAt){
+function isUserOnTrialPeriod(createdAt){
   const createdAtDate = new Date(createdAt);
   const actualDate = new Date();
   const DAYS_TO_TRY = 30;

--- a/api/controllers/user.js
+++ b/api/controllers/user.js
@@ -114,7 +114,9 @@ async function passportLogin(ip, type, accessToken, refreshToken, profile, done)
       user = await createOrUpdateUser(accessToken, profile, type);
     }
 
-    if (!user.location || !user.location.country)
+    const isOnTryPeriod = (user.createdAt);
+
+    if (!user.location || !user.location.countryisUserOnTryPeriod)
       try {
         await updateUserLocation(ip, user);
       } catch (error) {
@@ -132,7 +134,8 @@ async function passportLogin(ip, type, accessToken, refreshToken, profile, done)
     const response = {
       ...user.toJSON(),
       settings,
-      authToken: tokenString
+      authToken: tokenString,
+      isOnTryPeriod
     };
 
     done(null, response);

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -83,7 +83,12 @@ const USER_SCHEMA_DEFINITION = {
   isFirstLogin: {
     type: Boolean,
     required: false
-  }
+  },
+  isOnTryPeriod: {
+    type: Boolean,
+    required: false,
+    default: true
+  },
 };
 
 const USER_SCHEMA_OPTIONS = {

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -84,7 +84,7 @@ const USER_SCHEMA_DEFINITION = {
     type: Boolean,
     required: false
   },
-  isOnTryPeriod: {
+  isOnTrialPeriod: {
     type: Boolean,
     required: false,
     default: true

--- a/test/controllers/user.js
+++ b/test/controllers/user.js
@@ -104,9 +104,9 @@ describe('User API calls', function () {
           res.body.should.to.have.property('createdAt');
         })
 
-        it('it should contain a field indicating if user is on try period', function() {
-          res.body.should.to.have.property('isOnTryPeriod');
-          res.body.isOnTryPeriod.should.be.true;
+        it('it should contain a field indicating if user is on trial period', function() {
+          res.body.should.to.have.property('isOnTrialPeriod');
+          res.body.isOnTrialPeriod.should.be.true;
         })
       });
     });

--- a/test/controllers/user.js
+++ b/test/controllers/user.js
@@ -103,6 +103,11 @@ describe('User API calls', function () {
         it('it should contain a field indicating the user created date', function() {
           res.body.should.to.have.property('createdAt');
         })
+
+        it('it should contain a field indicating if user is on try period', function() {
+          res.body.should.to.have.property('isOnTryPeriod');
+          res.body.isOnTryPeriod.should.be.true;
+        })
       });
     });
   });


### PR DESCRIPTION
This PR uses the CreatedAt property of users to determine if it is on the trial period of 30 days and returns the result on userData responses.
With this logic. Users Created before release #258 changes are not on the trial period.