### PR TITLE
Validate domain before send verification email

### DIFF
--- a/api/controllers/user.js
+++ b/api/controllers/user.js
@@ -13,6 +13,9 @@ const auth = require('../helpers/auth');
 const { findIpLocation, isLocalIp } = require('../helpers/localize');
 const Subscribers = require('../models/Subscribers');
 
+const config = require('../../config');
+const { CBOARD_PROD_URL, CBOARD_QA_URL, LOCALHOST_PORT_3000_URL } = config;
+
 module.exports = {
   createUser: createUser,
   activateUser: activateUser,
@@ -99,9 +102,12 @@ async function createUser(req, res) {
       const URL = newTempUser[nev.options.URLFieldName];
 
       let domain = req.headers.origin;
+
+      const isValidDomain = domain =>
+        [CBOARD_PROD_URL, CBOARD_QA_URL, LOCALHOST_PORT_3000_URL].includes(domain);
       //if origin is private insert default hostname
-      if (!domain) {
-        domain = 'https://app.cboard.io'
+      if (!domain || !isValidDomain(domain)) {
+        domain = CBOARD_PROD_URL;
       }
 
       nev.sendVerificationEmail(newTempUser.email, domain, URL, function (err, info) {
@@ -523,9 +529,12 @@ async function forgotPassword(req, res) {
         //User id, the token generated and user domain are sent as params in a link
 
         let domain = req.headers.origin;
+
+        const isValidDomain = domain =>
+        [CBOARD_PROD_URL, CBOARD_QA_URL, LOCALHOST_PORT_3000_URL].includes(domain);
         //if origin is private insert default hostname
-        if (!domain) {
-          domain = 'https://app.cboard.io'
+        if (!domain || !isValidDomain(domain)) {
+          domain = CBOARD_PROD_URL;
         }
 
         nev.sendResetPasswordEmail(user.email, domain, user.id, token, function (err) {

--- a/config/env/development.js
+++ b/config/env/development.js
@@ -55,5 +55,8 @@ module.exports = {
   },
   appInsightConnectionString: process.env.APPLICATIONINSIGHTS_CONNECTION_STRING,
   GOOGLE_PLAY_CREDENTIALS: process.env.GOOGLE_PLAY_CREDENTIALS,
-  PAYPAL_API_URL: 'https://api-m.sandbox.paypal.com/v1/'
+  PAYPAL_API_URL: 'https://api-m.sandbox.paypal.com/v1/',
+  CBOARD_PROD_URL: 'https://app.cboard.io',
+  CBOARD_QA_URL: 'https://app.qa.cboard.io',
+  LOCALHOST_PORT_3000_URL: 'http://localhost:3000',
 };

--- a/config/env/production.js
+++ b/config/env/production.js
@@ -55,6 +55,8 @@ module.exports = {
   },
   appInsightConnectionString: process.env.APPLICATIONINSIGHTS_CONNECTION_STRING,
   GOOGLE_PLAY_CREDENTIALS: process.env.GOOGLE_PLAY_CREDENTIALS,
-  PAYPAL_API_URL: 'https://api-m.paypal.com/'
-
+  PAYPAL_API_URL: 'https://api-m.paypal.com/',
+  CBOARD_PROD_URL: 'https://app.cboard.io',
+  CBOARD_QA_URL: 'https://app.qa.cboard.io',
+  LOCALHOST_PORT_3000_URL: 'http://localhost',
 };


### PR DESCRIPTION
On this PR: 
-  3 new env were added: `CBOARD_PROD_URL, CBOARD_QA_URL, LOCALHOST_PORT_3000_URL`
-  If the domain of the incoming request is undefined or is not included by the new envs, the activation URL will contain the CBOARD_PROD_URL domain.