### PR TITLE
Fix get location endpoint if the ip includes the port

### DIFF
--- a/api/controllers/location.js
+++ b/api/controllers/location.js
@@ -6,7 +6,8 @@ module.exports = {
 
 async function location(req, res) {
     try {
-        const location = await findIpLocation(req.ip)
+        const ip = req.ip.split(':')[0];
+        const location = await findIpLocation(ip)
         delete location.ip;
         res.status(200).json(location);
     } catch (error) {


### PR DESCRIPTION
Splited the req.IP of GET location to remove the port of the IP address before obtaining the location.
close #343 