### PR TITLE
Adding new endpoint to allow external apps to trigger oauth login steps

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+swagger.yaml

--- a/api/controllers/user.js
+++ b/api/controllers/user.js
@@ -147,7 +147,6 @@ async function proxyOauth(req, res) {
 }
 // Login from Facebook or Google
 async function passportLogin(ip, type, accessToken, refreshToken, profile, done) {
-  console.log("profile",profile);
   try {
     const propertyId = USER_MODEL_ID_TYPE[type];
     let user = await User.findOne({ [propertyId]: profile.id })

--- a/api/controllers/user.js
+++ b/api/controllers/user.js
@@ -32,7 +32,8 @@ module.exports = {
   appleLogin,
   googleIdTokenLogin,
   forgotPassword: forgotPassword,
-  storePassword: storePassword
+  storePassword: storePassword,
+  proxyOauth: proxyOauth,
 };
 
 const USER_MODEL_ID_TYPE = {
@@ -137,8 +138,16 @@ async function createUser(req, res) {
   });
 }
 
+async function proxyOauth(req, res) {
+  const {accessToken, refreshToken, profile} = req.body;
+  const provider = req.swagger.params.provider.value;
+  return passportLogin('', provider, accessToken, refreshToken, profile, (req, authRes) => {
+    res.json(authRes);
+  })
+}
 // Login from Facebook or Google
 async function passportLogin(ip, type, accessToken, refreshToken, profile, done) {
+  console.log("profile",profile);
   try {
     const propertyId = USER_MODEL_ID_TYPE[type];
     let user = await User.findOne({ [propertyId]: profile.id })

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -704,6 +704,39 @@ paths:
           description: Error
           schema:
             $ref: "#/definitions/ErrorResponse"
+  /login/passport/{provider}:
+    x-swagger-router-controller: user
+    post:
+      operationId: proxyOauth
+      description: "Allows other applications to trigger oauth database changes without triggering the callback processes (Currently used in CBoard AI Builder)"
+      parameters:
+        - in: path
+          name: provider
+          required: true
+          type: string
+        - in: body
+          name: 'data'
+          required: true
+          schema:
+            properties: 
+              accessToken:
+                type: string
+              refreshToken:
+                type: string
+              profile:
+                type: object
+              
+      responses:
+          "200":
+            description: Success
+            schema:
+              $ref: "#/definitions/GetUserResponse"
+          default:
+            description: Error
+            schema:
+              $ref: "#/definitions/ErrorResponse"
+
+
   /user/login:
     x-swagger-router-controller: user
     post:

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -704,7 +704,7 @@ paths:
           description: Error
           schema:
             $ref: "#/definitions/ErrorResponse"
-  /login/passport/{provider}:
+  /login/oauth/{provider}:
     x-swagger-router-controller: user
     post:
       operationId: proxyOauth
@@ -714,6 +714,10 @@ paths:
           name: provider
           required: true
           type: string
+          enum:
+            - google
+            - facebook
+            - apple
         - in: body
           name: 'data'
           required: true
@@ -725,7 +729,6 @@ paths:
                 type: string
               profile:
                 type: object
-              
       responses:
           "200":
             description: Success
@@ -735,8 +738,6 @@ paths:
             description: Error
             schema:
               $ref: "#/definitions/ErrorResponse"
-
-
   /user/login:
     x-swagger-router-controller: user
     post:


### PR DESCRIPTION
Needed as part of https://github.com/cboard-org/cboard-ai-builder/issues/25.
- Adds a new endpoint to allow other apps to trigger oauth actions without doing a callback redirection