### PR TITLE
Feature/CbuilderConnection

### DIFF
--- a/api/helpers/cbuilder.js
+++ b/api/helpers/cbuilder.js
@@ -1,0 +1,16 @@
+const axios = require('axios');
+const config = require('../../config');
+const { INTERNAL_API_KEY, CBUILDER_API_URL } = config;
+
+async function getCbuilderBoardbyId(id) {
+  const res = await axios.get(CBUILDER_API_URL + '/api/board/' + id, {
+    headers: {
+      'Authorization': `Bearer ${INTERNAL_API_KEY}`
+    }
+  });
+  return res.data;
+}
+
+module.exports = {
+  getCbuilderBoardbyId: getCbuilderBoardbyId
+};

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -360,6 +360,31 @@ paths:
           description: Error
           schema:
             $ref: "#/definitions/ErrorResponse"
+  /board/cbuilder/{id}:
+    x-swagger-router-controller: board
+    get:
+      operationId: getCbuilderBoard
+      description: Returns a specific board from CBuilder
+      security:
+        - Bearer: []
+      x-security-scopes:
+        - admin
+        - user
+      parameters:
+        - name: id
+          type: string
+          in: path
+          required: true
+          minimum: 1
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/GetBoardResponse"
+        default:
+          description: Error
+          schema:
+            $ref: "#/definitions/ErrorResponse"
   /communicator:
     x-swagger-router-controller: communicator
     post:

--- a/config/env/development.js
+++ b/config/env/development.js
@@ -59,4 +59,6 @@ module.exports = {
   CBOARD_PROD_URL: 'https://app.cboard.io',
   CBOARD_QA_URL: 'https://app.qa.cboard.io',
   LOCALHOST_PORT_3000_URL: 'http://localhost:3000',
+  INTERNAL_API_KEY: process.env.INTERNAL_API_KEY,
+  CBUILDER_API_URL: process.env.CBUILDER_APP_URL || 'http://localhost:3000'
 };

--- a/config/env/production.js
+++ b/config/env/production.js
@@ -60,4 +60,6 @@ module.exports = {
   CBOARD_PROD_URL: 'https://app.cboard.io',
   CBOARD_QA_URL: 'https://app.qa.cboard.io',
   LOCALHOST_PORT_3000_URL: 'http://localhost',
+  INTERNAL_API_KEY: process.env.INTERNAL_API_KEY,
+  CBUILDER_API_URL: process.env.CBUILDER_APP_URL || 'http://localhost:3000'
 };


### PR DESCRIPTION
On this PR:
- Add new endpoint: `/board/cbuilder/id` to get the Cbuilder board. This make a get HTTP request to the Cbuilder API to get the board and return it to the Cboard app.
- New env `INTERNAL_API_KEY` added