### PR TITLE
Remove gapiAuth() from analytics controller

### DIFF
--- a/api/controllers/analytics.js
+++ b/api/controllers/analytics.js
@@ -99,5 +99,3 @@ async function userActivity(req, res) {
     });
   }
 }
-
-gapiAuth();

--- a/api/controllers/analytics.js
+++ b/api/controllers/analytics.js
@@ -3,6 +3,7 @@
 const { google } = require('googleapis');
 const analyticsreporting = google.analyticsreporting('v4');
 const constants = require('../constants');
+const config = require('../../config');
 
 module.exports = {
   batchGet: batchGet,
@@ -11,7 +12,10 @@ module.exports = {
 
 async function gapiAuth() {
   const scopes = ['https://www.googleapis.com/auth/analytics'];
-  const auth = new google.auth.GoogleAuth({ scopes: scopes });
+  const auth = new google.auth.GoogleAuth({
+    keyFile: config.GOOGLE_APPLICATION_CREDENTIALS,
+    scopes: scopes
+  });
   const authClient = await auth.getClient();
   google.options({ auth: authClient });
 }

--- a/config/env/development.js
+++ b/config/env/development.js
@@ -55,6 +55,7 @@ module.exports = {
   },
   appInsightConnectionString: process.env.APPLICATIONINSIGHTS_CONNECTION_STRING,
   GOOGLE_PLAY_CREDENTIALS: process.env.GOOGLE_PLAY_CREDENTIALS,
+  GOOGLE_APPLICATION_CREDENTIALS: process.env.GOOGLE_APPLICATION_CREDENTIALS,
   PAYPAL_API_URL: 'https://api-m.sandbox.paypal.com/v1',
   CBOARD_PROD_URL: 'https://app.cboard.io',
   CBOARD_QA_URL: 'https://app.qa.cboard.io',

--- a/config/env/production.js
+++ b/config/env/production.js
@@ -56,6 +56,7 @@ module.exports = {
   },
   appInsightConnectionString: process.env.APPLICATIONINSIGHTS_CONNECTION_STRING,
   GOOGLE_PLAY_CREDENTIALS: process.env.GOOGLE_PLAY_CREDENTIALS,
+  GOOGLE_APPLICATION_CREDENTIALS: process.env.GOOGLE_APPLICATION_CREDENTIALS,
   PAYPAL_API_URL: 'https://api-m.paypal.com/',
   CBOARD_PROD_URL: 'https://app.cboard.io',
   CBOARD_QA_URL: 'https://app.qa.cboard.io',


### PR DESCRIPTION
Eliminate the gapiAuth() call in the analytics controller that was causing the API  crash on initialization 

close #388