### PR TITLE
Fix double response error in board updateBoard function with async/await

### DIFF
--- a/api/controllers/board.js
+++ b/api/controllers/board.js
@@ -128,39 +128,44 @@ function getBoard(req, res) {
   });
 }
 
-function updateBoard(req, res) {
+async function updateBoard(req, res) {
   const id = req.swagger.params.id.value;
-  Board.findOne({ _id: id }, function (err, board) {
-    if (err) {
-      return res.status(500).json({
-        message: 'Error updating board. ',
-        error: err.message
-      });
-    }
+
+  try {
+    const board = await Board.findOne({ _id: id });
+    
     if (!board) {
       return res.status(404).json({
         message: 'Unable to find board. board Id: ' + id
       });
     }
+    
     for (let key in req.body) {
       board[key] = req.body[key];
     }
     board.lastEdited = moment().format();
-    board.save(function (err, board) {
-      if (err) {
-        return res.status(500).json({
-          message: 'Error saving board. ',
-          error: err.message
-        });
-      }
-      if (!board) {
+    
+    try {
+      const savedBoard = await board.save();
+      if (!savedBoard) {
         return res.status(404).json({
           message: 'Unable to find board. board id: ' + id
         });
       }
+      return res.status(200).json(savedBoard.toJSON());
+    } catch (err) {
+      return res.status(500).json({
+        message: 'Error saving board. ',
+        error: err.message
+      });
+    }
+    
+  } catch (err) {
+    return res.status(500).json({
+      message: 'Error updating board. ',
+      error: err.message
     });
-    return res.status(200).json(board.toJSON());
-  });
+  }
 }
 
 function reportPublicBoard(req,res){


### PR DESCRIPTION
Refactored the `updateBoard` function in `api/controllers/board.js` to use async/await instead of callbacks, improving readability and error handling. The main logic remains the same, but error responses and the save operation are now handled with modern JavaScript practices.

Changes:
* Converted `updateBoard` from a callback-based function to an `async` function using async/await for operations, making the code easier to read and maintain.
* Improved error handling by using try/catch blocks for both the board lookup and save operations, providing more accurate error responses.
* Ensured that the API returns proper HTTP status codes and messages for not found and error scenarios, both when searching for the board and when saving it.

closes #404 