### PR TITLE
Fix incorrect error variable reference casing ReferenceError

### DIFF
--- a/api/controllers/user.js
+++ b/api/controllers/user.js
@@ -425,7 +425,7 @@ function updateUser(req, res) {
       catch (e) {
         return res.status(500).json({
           message: 'Error saving user. ',
-          error: err.message
+          error: e.message
         });
       }
     });


### PR DESCRIPTION
Minor fix to the error handling in the `updateUser` controller. The change ensures that the correct error variable is referenced in the response.

* Fixed a bug in `updateUser` by returning the caught exception's message (`e.message`) instead of an undefined variable (`err.message`) in the error response.