### PR TITLE
Refactor syncSubscription function to prevent double response errors

### DIFF
--- a/api/controllers/subscription.js
+++ b/api/controllers/subscription.js
@@ -119,14 +119,12 @@ async function syncSubscriptions(req, res) {
   await gapiAuth();
   const params = { packageName: 'com.unicef.cboard' };
   let paypalPlans = [];
-  
   // get PayPal plans 
   try {
     paypalPlans = await paypal.listPlans();
   } catch (err) {
     console.log(err.message);
   }
-  
   try {
     // get subscriptions from Google API
     const remoteData = await playConsole.monetization.subscriptions.list(params);
@@ -136,11 +134,11 @@ async function syncSubscriptions(req, res) {
     for (const subscription of remoteSubscrs) {
       try {
         const subscriptionId = subscription.productId;
-        const subscr = await Subscription.findOne({ subscriptionId: subscriptionId });
+        const userSubscription = await Subscription.findOne({ subscriptionId: subscriptionId });
         
         let newSubscription = undefined;
-        if (subscr) {
-          newSubscription = Object.assign(subscr, mapRemoteSubscr(subscription, paypalPlans.plans));
+        if (userSubscription) {
+          newSubscription = Object.assign(userSubscription, mapRemoteSubscr(subscription, paypalPlans.plans));
         } else {
           newSubscription = new Subscription(mapRemoteSubscr(subscription, paypalPlans.plans));
         }
@@ -161,7 +159,6 @@ async function syncSubscriptions(req, res) {
     const searchFields = ['name'];
     const query = search && search.length ? getORQuery(searchFields, search, true) : {};
     const localSubscrs = await paginatedResponse(Subscription, { query }, req.query);
-    
     // check the local subscription against remote 
     for (const localSubscr of localSubscrs.data) {
       try {

--- a/api/controllers/subscription.js
+++ b/api/controllers/subscription.js
@@ -119,27 +119,25 @@ async function syncSubscriptions(req, res) {
   await gapiAuth();
   const params = { packageName: 'com.unicef.cboard' };
   let paypalPlans = [];
+  
   // get PayPal plans 
   try {
     paypalPlans = await paypal.listPlans();
   } catch (err) {
     console.log(err.message);
   }
+  
   try {
     // get subscriptions from Google API
     const remoteData = await playConsole.monetization.subscriptions.list(params);
     const remoteSubscrs = remoteData.data.subscriptions;
-    //loop remote subscriptions
-    remoteSubscrs.forEach(subscription => {
-      //console.log(subscription);
-      const subscriptionId = subscription.productId;
-      Subscription.findOne({ subscriptionId: subscriptionId }, async function (err, subscr) {
-        if (err) {
-          return res.status(500).json({
-            message: 'Error getting subscription.',
-            error: err.message
-          });
-        }
+    
+    // loop remote subscriptions
+    for (const subscription of remoteSubscrs) {
+      try {
+        const subscriptionId = subscription.productId;
+        const subscr = await Subscription.findOne({ subscriptionId: subscriptionId });
+        
         let newSubscription = undefined;
         if (subscr) {
           newSubscription = Object.assign(subscr, mapRemoteSubscr(subscription, paypalPlans.plans));
@@ -147,63 +145,54 @@ async function syncSubscriptions(req, res) {
           newSubscription = new Subscription(mapRemoteSubscr(subscription, paypalPlans.plans));
         }
 
-        await newSubscription.save(function (err, result) {
-          if (err) {
-            console.error('error', err);
-            return res.status(409).json({
-              message: 'Error saving subscription',
-              error: err.message,
-            });
-          } else {
-            if (!subscr) {
-              console.log("New subscription added: " + result.name);
-            } else {
-              console.log("Subscription updated: " + result.name);
-            }
-          }
-        });
-      });
-    });
+        const result = await newSubscription.save();
+        if (!subscr) {
+          console.log("New subscription added: " + result.name);
+        } else {
+          console.log("Subscription updated: " + result.name);
+        }
+      } catch (err) {
+        console.error('Error processing subscription:', err);
+      }
+    }
+    
     // get subscriptions from database 
     const { search = '' } = req.query;
     const searchFields = ['name'];
     const query = search && search.length ? getORQuery(searchFields, search, true) : {};
     const localSubscrs = await paginatedResponse(Subscription, { query }, req.query);
+    
     // check the local subscription against remote 
-    localSubscrs.data.forEach(localSubscr => {
-      const id = localSubscr.subscriptionId;
-      let found = false;
-      remoteSubscrs.forEach(remoteSubscr => {
-        remoteSubscr = mapRemoteSubscr(remoteSubscr, paypalPlans.plans);
-        if (id == remoteSubscr.subscriptionId) found = true;
-      });
-      if (!found) {
-        Subscription.findOneAndDelete({ id }, function (
-          err,
-          deletedSubscr
-        ) {
-          if (err) {
-            return res.status(500).json({
-              message: 'Error deleting subscription. ',
-              error: err.message,
-            });
+    for (const localSubscr of localSubscrs.data) {
+      try {
+        const id = localSubscr.subscriptionId;
+        let found = false;
+        
+        for (const remoteSubscr of remoteSubscrs) {
+          const mappedRemoteSubscr = mapRemoteSubscr(remoteSubscr, paypalPlans.plans);
+          if (id == mappedRemoteSubscr.subscriptionId) {
+            found = true;
+            break;
           }
-          if (!deletedSubscr) {
-            return res.status(404).json({
-              message:
-                'Subscription does not exist. Subscription Id: ' + id,
-            });
+        }
+        
+        if (!found) {
+          const deletedSubscr = await Subscription.findOneAndDelete({ subscriptionId: id });
+          if (deletedSubscr) {
+            console.log("Subscription deleted: " + deletedSubscr.name);
           }
-          console.log("Subscription deleted: " + deletedSubscr.name);
-        });
+        }
+      } catch (err) {
+        console.error('Error processing local subscription:', err);
       }
-    });
+    }
 
     return res.status(200).json(localSubscrs);
   } catch (err) {
     console.log(err.message);
     return res.status(500).json({
-      message: err.message
+      message: 'Error synchronizing subscriptions',
+      error: err.message
     });
   }
 }

--- a/api/controllers/user.js
+++ b/api/controllers/user.js
@@ -425,7 +425,7 @@ function updateUser(req, res) {
       catch (e) {
         return res.status(500).json({
           message: 'Error saving user. ',
-          error: err.message
+          error: e.message
         });
       }
     });


### PR DESCRIPTION
Refactored the `syncSubscriptions` function in `subscription.js` to improve error handling, code readability, and asynchronous processing. The main changes involve replacing nested callbacks with async/await, improving error reporting, and making the subscription synchronization logic more robust.

**Changes:**
* Replaced nested callback-based logic with `async/await` for database operations in the main synchronization loop, resulting in clearer and more maintainable code.
* Added try/catch blocks around both the remote and local subscription processing loops to ensure individual errors are logged without interrupting the entire synchronization process.
* Improved error reporting in API responses by providing more descriptive messages and including error details in the response body.
* Changed the remote and local subscription loops from `forEach` to `for...of` to support asynchronous operations within the loops.
* Updated the logic for deleting local subscriptions that no longer exist remotely to use `findOneAndDelete` with async/await, and to log successful deletions.

closes #407 

PS. I made a mistake in the name of the first commit so I ammend it, I also forgot to pull from main branch that's why I have a merge.