### PR TITLE
Enforces authentication for reporting boards

### DIFF
--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -347,6 +347,11 @@ paths:
     post:
       operationId: reportPublicBoard
       description: Send an email to report that a public board contains inappropriate content.
+      security:
+        - Bearer: []
+      x-security-scopes:
+        - admin
+        - user
       parameters:
           - name: report
             in: body


### PR DESCRIPTION
Adds security definitions and scopes to the "reportPublicBoard" endpoint in the API specification.

This ensures that only authenticated users (with either "admin" or "user" scopes) can report inappropriate content on public boards.
