### PR TITLE
Configures Mongoose with `useFindAndModify: false`

### DIFF
--- a/db.js
+++ b/db.js
@@ -4,7 +4,10 @@ var mongoose = require('mongoose');
 var config = require('./config');
 const seeds = require('./seeds');
 
-mongoose.connect(config.databaseUrl, { useNewUrlParser: true });
+mongoose.connect(config.databaseUrl, { 
+  useNewUrlParser: true,
+  useFindAndModify: false
+});
 mongoose.connection.on('connected', () => {
   console.log('Connected to ' + config.env + ' database ');
   seeds();


### PR DESCRIPTION
The `useFindAndModify: false` option is added to the Mongoose connection configuration. This disables the use of `findOneAndUpdate()` and `findOneAndDelete()` to use `findAndUpdate()` and `findOneAndDelete()` instead. This ensures the MongoDB driver uses the latest features.
