### PR TITLE
Add accessCode field to Board model schema

### DIFF
--- a/api/models/Board.js
+++ b/api/models/Board.js
@@ -65,7 +65,6 @@ const BOARD_SCHEMA_DEFINITION = {
   grid: {},
   accessCode: {
     type: String,
-    default: null,
     trim: true,
     uppercase: true
   }
@@ -87,7 +86,7 @@ const BOARD_SCHEMA_OPTIONS = {
 
 const boardSchema = new Schema(BOARD_SCHEMA_DEFINITION, BOARD_SCHEMA_OPTIONS);
 
-// Sparse index allows multiple null values while indexing non-null accessCodes
+// Sparse index skips documents where accessCode is missing, optimizing queries for Access boards
 boardSchema.index({ accessCode: 1 }, { sparse: true });
 
 const validatePresenceOf = value => value && value.length;

--- a/api/models/Board.js
+++ b/api/models/Board.js
@@ -62,7 +62,13 @@ const BOARD_SCHEMA_DEFINITION = {
     type: Boolean,
     default: false
   },
-  grid: {}
+  grid: {},
+  accessCode: {
+    type: String,
+    default: null,
+    trim: true,
+    uppercase: true
+  }
 };
 
 const BOARD_SCHEMA_OPTIONS = {
@@ -80,6 +86,9 @@ const BOARD_SCHEMA_OPTIONS = {
 };
 
 const boardSchema = new Schema(BOARD_SCHEMA_DEFINITION, BOARD_SCHEMA_OPTIONS);
+
+// Sparse index allows multiple null values while indexing non-null accessCodes
+boardSchema.index({ accessCode: 1 }, { sparse: true });
 
 const validatePresenceOf = value => value && value.length;
 

--- a/test/controllers/board.js
+++ b/test/controllers/board.js
@@ -252,8 +252,8 @@ describe('Board API calls', function () {
     });
   });
 
-  describe('accessCode field behavior', function() {
-    it('should normalize accessCode to uppercase when creating a board', async function() {
+  describe('accessCode field behavior', function () {
+    it('should normalize accessCode to uppercase when creating a board', async function () {
       const boardWithAccessCode = {
         ...helper.boardData,
         accessCode: 'cafe01'
@@ -270,7 +270,7 @@ describe('Board API calls', function () {
       res.body.accessCode.should.equal('CAFE01');
     });
 
-    it('should trim whitespace from accessCode', async function() {
+    it('should trim whitespace from accessCode', async function () {
       const boardWithAccessCode = {
         ...helper.boardData,
         accessCode: '  test01  '
@@ -287,7 +287,7 @@ describe('Board API calls', function () {
       res.body.accessCode.should.equal('TEST01');
     });
 
-    it('should not include accessCode when not provided', async function() {
+    it('should not include accessCode when not provided', async function () {
       const boardWithoutAccessCode = { ...helper.boardData };
       delete boardWithoutAccessCode.accessCode;
 
@@ -302,7 +302,7 @@ describe('Board API calls', function () {
       res.body.should.not.have.property('accessCode');
     });
 
-    it('should update accessCode on an existing board', async function() {
+    it('should update accessCode on an existing board', async function () {
       const boardId = await helper.createMochaBoard(server, user.token);
 
       const updateData = {
@@ -321,7 +321,7 @@ describe('Board API calls', function () {
       res.body.accessCode.should.equal('UPDATED01');
     });
 
-    it('should return accessCode in GET response when set', async function() {
+    it('should return accessCode in GET response when set', async function () {
       const boardWithAccessCode = {
         ...helper.boardData,
         accessCode: 'gettest01'
@@ -331,6 +331,7 @@ describe('Board API calls', function () {
         .send(boardWithAccessCode)
         .set('Authorization', `Bearer ${user.token}`)
         .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
         .expect(200);
 
       const boardId = createRes.body.id;

--- a/test/controllers/board.js
+++ b/test/controllers/board.js
@@ -252,6 +252,101 @@ describe('Board API calls', function () {
     });
   });
 
+  describe('accessCode field behavior', function() {
+    it('should normalize accessCode to uppercase when creating a board', async function() {
+      const boardWithAccessCode = {
+        ...helper.boardData,
+        accessCode: 'cafe01'
+      };
+      const res = await request(server)
+        .post('/board')
+        .send(boardWithAccessCode)
+        .set('Authorization', `Bearer ${user.token}`)
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200);
+
+      res.body.should.have.property('accessCode');
+      res.body.accessCode.should.equal('CAFE01');
+    });
+
+    it('should trim whitespace from accessCode', async function() {
+      const boardWithAccessCode = {
+        ...helper.boardData,
+        accessCode: '  test01  '
+      };
+      const res = await request(server)
+        .post('/board')
+        .send(boardWithAccessCode)
+        .set('Authorization', `Bearer ${user.token}`)
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200);
+
+      res.body.should.have.property('accessCode');
+      res.body.accessCode.should.equal('TEST01');
+    });
+
+    it('should not include accessCode when not provided', async function() {
+      const boardWithoutAccessCode = { ...helper.boardData };
+      delete boardWithoutAccessCode.accessCode;
+
+      const res = await request(server)
+        .post('/board')
+        .send(boardWithoutAccessCode)
+        .set('Authorization', `Bearer ${user.token}`)
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200);
+
+      res.body.should.not.have.property('accessCode');
+    });
+
+    it('should update accessCode on an existing board', async function() {
+      const boardId = await helper.createMochaBoard(server, user.token);
+
+      const updateData = {
+        ...helper.boardData,
+        accessCode: 'updated01'
+      };
+      const res = await request(server)
+        .put('/board/' + boardId)
+        .send(updateData)
+        .set('Authorization', `Bearer ${user.token}`)
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200);
+
+      res.body.should.have.property('accessCode');
+      res.body.accessCode.should.equal('UPDATED01');
+    });
+
+    it('should return accessCode in GET response when set', async function() {
+      const boardWithAccessCode = {
+        ...helper.boardData,
+        accessCode: 'gettest01'
+      };
+      const createRes = await request(server)
+        .post('/board')
+        .send(boardWithAccessCode)
+        .set('Authorization', `Bearer ${user.token}`)
+        .set('Accept', 'application/json')
+        .expect(200);
+
+      const boardId = createRes.body.id;
+
+      const getRes = await request(server)
+        .get('/board/' + boardId)
+        .set('Authorization', `Bearer ${user.token}`)
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200);
+
+      getRes.body.should.have.property('accessCode');
+      getRes.body.accessCode.should.equal('GETTEST01');
+    });
+  });
+
   describe('GET /board/byemail/:email', function() {
     it("only allows an admin to get another user's boards", async function() {
       const adminEmail = helper.generateEmail();


### PR DESCRIPTION
Adds support for an optional access code on boards, including schema changes and indexing to optimize queries involving the new field.

Schema changes:
* Added an `accessPointCode` field to the `Board` schema, which is an optional, trimmed, and uppercased string.

Indexing improvements:
* Created a sparse index on the `accessPointCode` field to efficiently support queries and allow multiple boards with a `null` access code.

Closes cboard-org/cboard-api#440