### PR TITLE
Create AccessClient model

### DIFF
--- a/api/models/AccessClient.js
+++ b/api/models/AccessClient.js
@@ -3,35 +3,6 @@
 const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
 
-const accessPointSchema = new Schema(
-  {
-    code: {
-      type: String,
-      required: true,
-      trim: true,
-      uppercase: true
-    },
-    rootBoardId: {
-      type: Schema.Types.ObjectId,
-      ref: 'Board',
-      required: true
-    },
-    isListedInApp: {
-      type: Boolean,
-      default: true
-    },
-    accessCount: {
-      type: Number,
-      default: 0
-    },
-    lastAccessAt: {
-      type: Date,
-      default: null
-    }
-  },
-  { _id: true }
-);
-
 const ACCESS_CLIENT_SCHEMA_DEFINITION = {
   slug: {
     type: String,
@@ -71,8 +42,7 @@ const ACCESS_CLIENT_SCHEMA_DEFINITION = {
     type: Schema.Types.ObjectId,
     ref: 'User',
     required: true
-  },
-  accessPoints: [accessPointSchema]
+  }
 };
 
 const ACCESS_CLIENT_SCHEMA_OPTIONS = {

--- a/api/models/AccessClient.js
+++ b/api/models/AccessClient.js
@@ -1,0 +1,86 @@
+'use strict';
+
+const mongoose = require('mongoose');
+const Schema = mongoose.Schema;
+
+const ACCESS_CLIENT_SCHEMA_DEFINITION = {
+  code: {
+    type: String,
+    unique: true,
+    required: true,
+    trim: true,
+    uppercase: true
+  },
+  clientName: {
+    type: String,
+    required: true,
+    trim: true
+  },
+  clientContact: {
+    type: String,
+    trim: true
+  },
+  brandColor: {
+    type: String
+  },
+  rootBoardId: {
+    type: Schema.Types.ObjectId,
+    ref: 'Board',
+    required: true
+  },
+  isActive: {
+    type: Boolean,
+    default: true
+  },
+  isListedInApp: {
+    type: Boolean,
+    default: true
+  },
+  subscriptionStart: {
+    type: Date,
+    required: true
+  },
+  subscriptionEnd: {
+    type: Date,
+    required: true
+  },
+  accessCount: {
+    type: Number,
+    default: 0
+  },
+  lastAccessAt: {
+    type: Date
+  },
+  createdBy: {
+    type: Schema.Types.ObjectId,
+    ref: 'User',
+    required: true
+  }
+};
+
+const ACCESS_CLIENT_SCHEMA_OPTIONS = {
+  timestamps: true,
+  toObject: {
+    virtuals: true
+  },
+  toJSON: {
+    virtuals: true,
+    versionKey: false,
+    transform: function (doc, ret) {
+      ret.id = ret._id;
+      delete ret._id;
+    }
+  }
+};
+
+const accessClientSchema = new Schema(
+  ACCESS_CLIENT_SCHEMA_DEFINITION,
+  ACCESS_CLIENT_SCHEMA_OPTIONS
+);
+
+accessClientSchema.index({ code: 1 }, { unique: true });
+accessClientSchema.index({ isActive: 1, isListedInApp: 1 });
+
+const AccessClient = mongoose.model('AccessClient', accessClientSchema);
+
+module.exports = AccessClient;

--- a/api/models/AccessClient.js
+++ b/api/models/AccessClient.js
@@ -17,7 +17,11 @@ const ACCESS_CLIENT_SCHEMA_DEFINITION = {
       required: true,
       trim: true
     },
-    contact: {
+    email: {
+      type: String,
+      trim: true
+    },
+    phone: {
       type: String,
       trim: true
     }

--- a/api/models/AccessClient.js
+++ b/api/models/AccessClient.js
@@ -3,36 +3,59 @@
 const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
 
+const accessPointSchema = new Schema(
+  {
+    code: {
+      type: String,
+      required: true,
+      trim: true,
+      uppercase: true
+    },
+    rootBoardId: {
+      type: Schema.Types.ObjectId,
+      ref: 'Board',
+      required: true
+    },
+    isListedInApp: {
+      type: Boolean,
+      default: true
+    },
+    accessCount: {
+      type: Number,
+      default: 0
+    },
+    lastAccessAt: {
+      type: Date,
+      default: null
+    }
+  },
+  { _id: true }
+);
+
 const ACCESS_CLIENT_SCHEMA_DEFINITION = {
-  code: {
+  slug: {
     type: String,
     unique: true,
     required: true,
     trim: true,
-    uppercase: true
+    lowercase: true
   },
-  clientName: {
-    type: String,
-    required: true,
-    trim: true
-  },
-  clientContact: {
-    type: String,
-    trim: true
+  client: {
+    name: {
+      type: String,
+      required: true,
+      trim: true
+    },
+    contact: {
+      type: String,
+      trim: true
+    }
   },
   brandColor: {
-    type: String
-  },
-  rootBoardId: {
-    type: Schema.Types.ObjectId,
-    ref: 'Board',
-    required: true
+    type: String,
+    default: '#1976d2'
   },
   isActive: {
-    type: Boolean,
-    default: true
-  },
-  isListedInApp: {
     type: Boolean,
     default: true
   },
@@ -44,18 +67,12 @@ const ACCESS_CLIENT_SCHEMA_DEFINITION = {
     type: Date,
     required: true
   },
-  accessCount: {
-    type: Number,
-    default: 0
-  },
-  lastAccessAt: {
-    type: Date
-  },
   createdBy: {
     type: Schema.Types.ObjectId,
     ref: 'User',
     required: true
-  }
+  },
+  accessPoints: [accessPointSchema]
 };
 
 const ACCESS_CLIENT_SCHEMA_OPTIONS = {
@@ -66,7 +83,7 @@ const ACCESS_CLIENT_SCHEMA_OPTIONS = {
   toJSON: {
     virtuals: true,
     versionKey: false,
-    transform: function (doc, ret) {
+    transform: function(doc, ret) {
       ret.id = ret._id;
       delete ret._id;
     }
@@ -77,8 +94,6 @@ const accessClientSchema = new Schema(
   ACCESS_CLIENT_SCHEMA_DEFINITION,
   ACCESS_CLIENT_SCHEMA_OPTIONS
 );
-
-accessClientSchema.index({ isActive: 1, isListedInApp: 1 });
 
 const AccessClient = mongoose.model('AccessClient', accessClientSchema);
 

--- a/api/models/AccessClient.js
+++ b/api/models/AccessClient.js
@@ -78,7 +78,6 @@ const accessClientSchema = new Schema(
   ACCESS_CLIENT_SCHEMA_OPTIONS
 );
 
-accessClientSchema.index({ code: 1 }, { unique: true });
 accessClientSchema.index({ isActive: 1, isListedInApp: 1 });
 
 const AccessClient = mongoose.model('AccessClient', accessClientSchema);

--- a/api/models/AccessPoint.js
+++ b/api/models/AccessPoint.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const mongoose = require('mongoose');
+const Schema = mongoose.Schema;
+
+const ACCESS_POINT_SCHEMA_DEFINITION = {
+  code: {
+    type: String,
+    required: true,
+    trim: true,
+    uppercase: true,
+    unique: true,
+    index: true
+  },
+  accessClient: {
+    type: Schema.Types.ObjectId,
+    ref: 'AccessClient',
+    required: true
+  },
+  rootBoardId: {
+    type: Schema.Types.ObjectId,
+    ref: 'Board',
+    required: true
+  },
+  viewsCount: {
+    type: Number,
+    default: 0
+  },
+  lastAccessAt: {
+    type: Date,
+    default: null
+  }
+};
+
+const ACCESS_POINT_SCHEMA_OPTIONS = {
+  timestamps: true,
+  toObject: {
+    virtuals: true
+  },
+  toJSON: {
+    virtuals: true,
+    versionKey: false,
+    transform: function(doc, ret) {
+      ret.id = ret._id;
+      delete ret._id;
+    }
+  }
+};
+
+const accessPointSchema = new Schema(
+  ACCESS_POINT_SCHEMA_DEFINITION,
+  ACCESS_POINT_SCHEMA_OPTIONS
+);
+
+const AccessPoint = mongoose.model('AccessPoint', accessPointSchema);
+
+module.exports = AccessPoint;

--- a/api/models/AccessPoint.js
+++ b/api/models/AccessPoint.js
@@ -29,6 +29,11 @@ const ACCESS_POINT_SCHEMA_DEFINITION = {
   lastAccessAt: {
     type: Date,
     default: null
+  },
+  linkedBoardsIds: {
+    type: [Schema.Types.ObjectId],
+    ref: 'Board',
+    default: []
   }
 };
 

--- a/api/models/Board.js
+++ b/api/models/Board.js
@@ -65,7 +65,6 @@ const BOARD_SCHEMA_DEFINITION = {
   grid: {},
   accessCode: {
     type: String,
-    default: null,
     trim: true,
     uppercase: true
   }
@@ -87,7 +86,7 @@ const BOARD_SCHEMA_OPTIONS = {
 
 const boardSchema = new Schema(BOARD_SCHEMA_DEFINITION, BOARD_SCHEMA_OPTIONS);
 
-// Sparse index allows multiple null values while indexing non-null accessCodes
+// Sparse index skips documents where accessCode is missing, optimizing queries for Access boards
 boardSchema.index({ accessCode: 1 }, { sparse: true });
 
 const validatePresenceOf = value => value && value.length;

--- a/api/models/Board.js
+++ b/api/models/Board.js
@@ -67,7 +67,9 @@ const BOARD_SCHEMA_DEFINITION = {
     type: String,
     trim: true,
     uppercase: true,
-    default: null
+    default: null,
+    unique: true,
+    sparse: true
   }
 };
 
@@ -87,8 +89,8 @@ const BOARD_SCHEMA_OPTIONS = {
 
 const boardSchema = new Schema(BOARD_SCHEMA_DEFINITION, BOARD_SCHEMA_OPTIONS);
 
-// Sparse index skips documents where accessPointCode is null/missing, optimizing queries for Access boards
-boardSchema.index({ accessPointCode: 1 }, { sparse: true });
+// Sparse unique index skips documents where accessPointCode is null/missing, enforcing uniqueness only for set values
+boardSchema.index({ accessPointCode: 1 }, { sparse: true, unique: true });
 
 const validatePresenceOf = value => value && value.length;
 

--- a/api/models/Board.js
+++ b/api/models/Board.js
@@ -62,7 +62,13 @@ const BOARD_SCHEMA_DEFINITION = {
     type: Boolean,
     default: false
   },
-  grid: {}
+  grid: {},
+  accessCode: {
+    type: String,
+    default: null,
+    trim: true,
+    uppercase: true
+  }
 };
 
 const BOARD_SCHEMA_OPTIONS = {
@@ -80,6 +86,9 @@ const BOARD_SCHEMA_OPTIONS = {
 };
 
 const boardSchema = new Schema(BOARD_SCHEMA_DEFINITION, BOARD_SCHEMA_OPTIONS);
+
+// Sparse index allows multiple null values while indexing non-null accessCodes
+boardSchema.index({ accessCode: 1 }, { sparse: true });
 
 const validatePresenceOf = value => value && value.length;
 

--- a/api/models/Board.js
+++ b/api/models/Board.js
@@ -63,10 +63,11 @@ const BOARD_SCHEMA_DEFINITION = {
     default: false
   },
   grid: {},
-  accessCode: {
+  accessPointCode: {
     type: String,
     trim: true,
-    uppercase: true
+    uppercase: true,
+    default: null
   }
 };
 
@@ -86,8 +87,8 @@ const BOARD_SCHEMA_OPTIONS = {
 
 const boardSchema = new Schema(BOARD_SCHEMA_DEFINITION, BOARD_SCHEMA_OPTIONS);
 
-// Sparse index skips documents where accessCode is missing, optimizing queries for Access boards
-boardSchema.index({ accessCode: 1 }, { sparse: true });
+// Sparse index skips documents where accessPointCode is null/missing, optimizing queries for Access boards
+boardSchema.index({ accessPointCode: 1 }, { sparse: true });
 
 const validatePresenceOf = value => value && value.length;
 

--- a/api/models/Board.js
+++ b/api/models/Board.js
@@ -67,9 +67,7 @@ const BOARD_SCHEMA_DEFINITION = {
     type: String,
     trim: true,
     uppercase: true,
-    default: null,
-    unique: true,
-    sparse: true
+    default: null
   }
 };
 

--- a/test/controllers/board.js
+++ b/test/controllers/board.js
@@ -252,8 +252,8 @@ describe('Board API calls', function () {
     });
   });
 
-  describe('accessCode field behavior', function() {
-    it('should normalize accessCode to uppercase when creating a board', async function() {
+  describe('accessCode field behavior', function () {
+    it('should normalize accessCode to uppercase when creating a board', async function () {
       const boardWithAccessCode = {
         ...helper.boardData,
         accessCode: 'cafe01'
@@ -270,7 +270,7 @@ describe('Board API calls', function () {
       res.body.accessCode.should.equal('CAFE01');
     });
 
-    it('should trim whitespace from accessCode', async function() {
+    it('should trim whitespace from accessCode', async function () {
       const boardWithAccessCode = {
         ...helper.boardData,
         accessCode: '  test01  '
@@ -287,7 +287,7 @@ describe('Board API calls', function () {
       res.body.accessCode.should.equal('TEST01');
     });
 
-    it('should not include accessCode when not provided', async function() {
+    it('should not include accessCode when not provided', async function () {
       const boardWithoutAccessCode = { ...helper.boardData };
       delete boardWithoutAccessCode.accessCode;
 
@@ -302,7 +302,7 @@ describe('Board API calls', function () {
       res.body.should.not.have.property('accessCode');
     });
 
-    it('should update accessCode on an existing board', async function() {
+    it('should update accessCode on an existing board', async function () {
       const boardId = await helper.createMochaBoard(server, user.token);
 
       const updateData = {
@@ -321,7 +321,7 @@ describe('Board API calls', function () {
       res.body.accessCode.should.equal('UPDATED01');
     });
 
-    it('should return accessCode in GET response when set', async function() {
+    it('should return accessCode in GET response when set', async function () {
       const boardWithAccessCode = {
         ...helper.boardData,
         accessCode: 'gettest01'
@@ -331,6 +331,7 @@ describe('Board API calls', function () {
         .send(boardWithAccessCode)
         .set('Authorization', `Bearer ${user.token}`)
         .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
         .expect(200);
 
       const boardId = createRes.body.id;

--- a/test/controllers/board.js
+++ b/test/controllers/board.js
@@ -252,11 +252,11 @@ describe('Board API calls', function () {
     });
   });
 
-  describe('accessCode field behavior', function () {
-    it('should normalize accessCode to uppercase when creating a board', async function () {
+  describe('accessPointCode field behavior', function () {
+    it('should normalize accessPointCode to uppercase when creating a board', async function () {
       const boardWithAccessCode = {
         ...helper.boardData,
-        accessCode: 'cafe01'
+        accessPointCode: 'cafe01'
       };
       const res = await request(server)
         .post('/board')
@@ -266,14 +266,14 @@ describe('Board API calls', function () {
         .expect('Content-Type', /json/)
         .expect(200);
 
-      res.body.should.have.property('accessCode');
-      res.body.accessCode.should.equal('CAFE01');
+      res.body.should.have.property('accessPointCode');
+      res.body.accessPointCode.should.equal('CAFE01');
     });
 
-    it('should trim whitespace from accessCode', async function () {
+    it('should trim whitespace from accessPointCode', async function () {
       const boardWithAccessCode = {
         ...helper.boardData,
-        accessCode: '  test01  '
+        accessPointCode: '  test01  '
       };
       const res = await request(server)
         .post('/board')
@@ -283,13 +283,13 @@ describe('Board API calls', function () {
         .expect('Content-Type', /json/)
         .expect(200);
 
-      res.body.should.have.property('accessCode');
-      res.body.accessCode.should.equal('TEST01');
+      res.body.should.have.property('accessPointCode');
+      res.body.accessPointCode.should.equal('TEST01');
     });
 
-    it('should not include accessCode when not provided', async function () {
+    it('should default accessPointCode to null when not provided', async function () {
       const boardWithoutAccessCode = { ...helper.boardData };
-      delete boardWithoutAccessCode.accessCode;
+      delete boardWithoutAccessCode.accessPointCode;
 
       const res = await request(server)
         .post('/board')
@@ -299,15 +299,15 @@ describe('Board API calls', function () {
         .expect('Content-Type', /json/)
         .expect(200);
 
-      res.body.should.not.have.property('accessCode');
+      res.body.accessPointCode.should.equal(null);
     });
 
-    it('should update accessCode on an existing board', async function () {
+    it('should update accessPointCode on an existing board', async function () {
       const boardId = await helper.createMochaBoard(server, user.token);
 
       const updateData = {
         ...helper.boardData,
-        accessCode: 'updated01'
+        accessPointCode: 'updated01'
       };
       const res = await request(server)
         .put('/board/' + boardId)
@@ -317,14 +317,14 @@ describe('Board API calls', function () {
         .expect('Content-Type', /json/)
         .expect(200);
 
-      res.body.should.have.property('accessCode');
-      res.body.accessCode.should.equal('UPDATED01');
+      res.body.should.have.property('accessPointCode');
+      res.body.accessPointCode.should.equal('UPDATED01');
     });
 
-    it('should return accessCode in GET response when set', async function () {
+    it('should return accessPointCode in GET response when set', async function () {
       const boardWithAccessCode = {
         ...helper.boardData,
-        accessCode: 'gettest01'
+        accessPointCode: 'gettest01'
       };
       const createRes = await request(server)
         .post('/board')
@@ -343,8 +343,8 @@ describe('Board API calls', function () {
         .expect('Content-Type', /json/)
         .expect(200);
 
-      getRes.body.should.have.property('accessCode');
-      getRes.body.accessCode.should.equal('GETTEST01');
+      getRes.body.should.have.property('accessPointCode');
+      getRes.body.accessPointCode.should.equal('GETTEST01');
     });
   });
 

--- a/test/controllers/board.js
+++ b/test/controllers/board.js
@@ -252,6 +252,101 @@ describe('Board API calls', function () {
     });
   });
 
+  describe('accessCode field behavior', function() {
+    it('should normalize accessCode to uppercase when creating a board', async function() {
+      const boardWithAccessCode = {
+        ...helper.boardData,
+        accessCode: 'cafe01'
+      };
+      const res = await request(server)
+        .post('/board')
+        .send(boardWithAccessCode)
+        .set('Authorization', `Bearer ${user.token}`)
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200);
+
+      res.body.should.have.property('accessCode');
+      res.body.accessCode.should.equal('CAFE01');
+    });
+
+    it('should trim whitespace from accessCode', async function() {
+      const boardWithAccessCode = {
+        ...helper.boardData,
+        accessCode: '  test01  '
+      };
+      const res = await request(server)
+        .post('/board')
+        .send(boardWithAccessCode)
+        .set('Authorization', `Bearer ${user.token}`)
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200);
+
+      res.body.should.have.property('accessCode');
+      res.body.accessCode.should.equal('TEST01');
+    });
+
+    it('should not include accessCode when not provided', async function() {
+      const boardWithoutAccessCode = { ...helper.boardData };
+      delete boardWithoutAccessCode.accessCode;
+
+      const res = await request(server)
+        .post('/board')
+        .send(boardWithoutAccessCode)
+        .set('Authorization', `Bearer ${user.token}`)
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200);
+
+      res.body.should.not.have.property('accessCode');
+    });
+
+    it('should update accessCode on an existing board', async function() {
+      const boardId = await helper.createMochaBoard(server, user.token);
+
+      const updateData = {
+        ...helper.boardData,
+        accessCode: 'updated01'
+      };
+      const res = await request(server)
+        .put('/board/' + boardId)
+        .send(updateData)
+        .set('Authorization', `Bearer ${user.token}`)
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200);
+
+      res.body.should.have.property('accessCode');
+      res.body.accessCode.should.equal('UPDATED01');
+    });
+
+    it('should return accessCode in GET response when set', async function() {
+      const boardWithAccessCode = {
+        ...helper.boardData,
+        accessCode: 'gettest01'
+      };
+      const createRes = await request(server)
+        .post('/board')
+        .send(boardWithAccessCode)
+        .set('Authorization', `Bearer ${user.token}`)
+        .set('Accept', 'application/json')
+        .expect(200);
+
+      const boardId = createRes.body.id;
+
+      const getRes = await request(server)
+        .get('/board/' + boardId)
+        .set('Authorization', `Bearer ${user.token}`)
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200);
+
+      getRes.body.should.have.property('accessCode');
+      getRes.body.accessCode.should.equal('GETTEST01');
+    });
+  });
+
   describe('GET /board/byemail/:email', function() {
     it("only allows an admin to get another user's boards", async function() {
       const adminEmail = helper.generateEmail();


### PR DESCRIPTION
- Adds `api/models/AccessClient.js` — a new Mongoose model for Cboard Access clients, with access points embedded as a subdocument array instead of a separate collection

**Model design**
AccessClient stores institutions-level data (slug, client info, branding, subscription dates) and embeds all its access points in a single document. Each access point holds its own code, `rootBoardId`, and analytics fields (`accessCount`, `lastAccessAt`).

This avoids a separate AccessPoint collection and keeps all related data co-located — queries for GET `/api access/:clientSlug/:accessCode` hit a single document.

Closes cboard-org#441