### PR TITLE
Access controller with public endpoints

### DIFF
--- a/api/controllers/access.js
+++ b/api/controllers/access.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const AccessClient = require('../models/AccessClient');
+const AccessPoint = require('../models/AccessPoint');
 const Board = require('../models/Board');
 
 module.exports = {
@@ -10,37 +11,45 @@ module.exports = {
 
 /**
  * GET /access/clients
- * Lists active companies for Cboard Access listing in the app.
- * Returns clients where isActive=true, isListedInApp=true, and subscription is valid.
- * Populates rootBoard basic info (name, caption, tiles count).
- * Sorted by clientName.
+ * Lists all active clients with valid subscriptions and their access points.
+ * Returns each client with its access points and root board basic info.
+ * Sorted by client name.
  */
 async function getClients(req, res) {
   try {
     const now = new Date();
     const clients = await AccessClient.find({
       isActive: true,
-      isListedInApp: true,
       subscriptionStart: { $lte: now },
       subscriptionEnd: { $gte: now }
+    }).select('slug client brandColor');
+
+    const accessPoints = await AccessPoint.find({
+      accessClient: { $in: clients.map(c => c._id) }
     })
       .populate('rootBoardId', 'name caption tiles')
-      .select('code clientName brandColor rootBoardId')
-      .sort({ clientName: 1 });
+      .select('code rootBoardId accessClient');
 
-    const result = clients.map(client => ({
-      code: client.code,
-      clientName: client.clientName,
-      brandColor: client.brandColor,
-      rootBoard: client.rootBoardId
-        ? {
-            id: client.rootBoardId._id,
-            name: client.rootBoardId.name,
-            caption: client.rootBoardId.caption,
-            tilesCount: client.rootBoardId.tiles?.length || 0
-          }
-        : null
-    }));
+    const result = clients
+      .map(client => ({
+        slug: client.slug,
+        clientName: client.client.name,
+        brandColor: client.brandColor,
+        accessPoints: accessPoints
+          .filter(ap => ap.accessClient.toString() === client._id.toString())
+          .map(ap => ({
+            code: ap.code,
+            rootBoard: ap.rootBoardId
+              ? {
+                  id: ap.rootBoardId._id,
+                  name: ap.rootBoardId.name,
+                  caption: ap.rootBoardId.caption,
+                  tilesCount: ap.rootBoardId.tiles?.length || 0
+                }
+              : null
+          }))
+      }))
+      .sort((a, b) => a.clientName.localeCompare(b.clientName));
 
     return res.status(200).json({
       total: result.length,
@@ -58,32 +67,41 @@ async function getClients(req, res) {
  * GET /access/:code
  * Gets ALL boards for an access code in a single request.
  * This enables instant frontend navigation without additional requests.
- * Validates code exists and subscription is active.
- * Returns client info (code, name, color), all boards array, and rootBoardId.
- * Increments accessCount and updates lastAccessAt.
+ * Validates code exists and client subscription is active.
+ * Returns client info (slug, name, color), all boards array, and rootBoardId.
+ * Increments viewsCount and updates lastAccessAt on the AccessPoint.
  */
 async function getAccessBoard(req, res) {
   const code = req.swagger.params.code.value.toUpperCase();
 
   try {
     const now = new Date();
-    const client = await AccessClient.findOne({
-      code: code,
-      isActive: true,
-      subscriptionStart: { $lte: now },
-      subscriptionEnd: { $gte: now }
-    });
+    const accessPoint = await AccessPoint.findOne({ code }).populate(
+      'accessClient'
+    );
 
-    if (!client) {
+    if (!accessPoint) {
+      return res.status(404).json({
+        message: 'Invalid access code'
+      });
+    }
+
+    const client = accessPoint.accessClient;
+    if (
+      !client ||
+      !client.isActive ||
+      client.subscriptionStart > now ||
+      client.subscriptionEnd < now
+    ) {
       return res.status(404).json({
         message: 'Invalid or expired access code'
       });
     }
 
-    // Get ALL boards with this accessCode (exclude PII fields for public endpoint)
-    const boards = await Board.find({ accessCode: code }).select(
-      '-email -author'
-    );
+    // Fetch all linked boards (exclude PII fields for public endpoint)
+    const boards = await Board.find({
+      _id: { $in: accessPoint.linkedBoardsIds }
+    }).select('-email -author');
 
     if (!boards || boards.length === 0) {
       return res.status(404).json({
@@ -91,9 +109,9 @@ async function getAccessBoard(req, res) {
       });
     }
 
-    // Verify the rootBoard exists
+    // Verify the rootBoard exists among the linked boards
     const rootBoard = boards.find(
-      b => b._id.toString() === client.rootBoardId.toString()
+      b => b._id.toString() === accessPoint.rootBoardId.toString()
     );
     if (!rootBoard) {
       return res.status(404).json({
@@ -102,22 +120,22 @@ async function getAccessBoard(req, res) {
     }
 
     // Track access analytics atomically to avoid lost updates under concurrency
-    await AccessClient.updateOne(
-      { _id: client._id },
+    await AccessPoint.updateOne(
+      { _id: accessPoint._id },
       {
-        $inc: { accessCount: 1 },
+        $inc: { viewsCount: 1 },
         $set: { lastAccessAt: new Date() }
       }
     );
 
     return res.status(200).json({
       client: {
-        code: client.code,
-        name: client.clientName,
+        code: client.slug,
+        name: client.client.name,
         color: client.brandColor
       },
       boards: boards.map(b => b.toJSON()),
-      rootBoardId: client.rootBoardId.toString()
+      rootBoardId: accessPoint.rootBoardId.toString()
     });
   } catch (err) {
     return res.status(500).json({

--- a/api/controllers/access.js
+++ b/api/controllers/access.js
@@ -1,0 +1,122 @@
+'use strict';
+
+const AccessClient = require('../models/AccessClient');
+const Board = require('../models/Board');
+
+module.exports = {
+  getClients: getClients,
+  getAccessBoard: getAccessBoard
+};
+
+/**
+ * GET /access/clients
+ * Lists active companies for Cboard Access listing in the app.
+ * Returns clients where isActive=true, isListedInApp=true, and subscription is valid.
+ * Populates rootBoard basic info (name, caption, tiles count).
+ * Sorted by clientName.
+ */
+async function getClients(req, res) {
+  try {
+    const now = new Date();
+    const clients = await AccessClient.find({
+      isActive: true,
+      isListedInApp: true,
+      subscriptionStart: { $lte: now },
+      subscriptionEnd: { $gte: now }
+    })
+      .populate('rootBoardId', 'name caption tiles')
+      .select('code clientName brandColor rootBoardId')
+      .sort({ clientName: 1 });
+
+    const result = clients.map(client => ({
+      code: client.code,
+      clientName: client.clientName,
+      brandColor: client.brandColor,
+      rootBoard: client.rootBoardId
+        ? {
+            id: client.rootBoardId._id,
+            name: client.rootBoardId.name,
+            caption: client.rootBoardId.caption,
+            tilesCount: client.rootBoardId.tiles?.length || 0
+          }
+        : null
+    }));
+
+    return res.status(200).json({
+      total: result.length,
+      data: result
+    });
+  } catch (err) {
+    return res.status(500).json({
+      message: 'Error listing clients',
+      error: err.message
+    });
+  }
+}
+
+/**
+ * GET /access/:code
+ * Gets ALL boards for an access code in a single request.
+ * This enables instant frontend navigation without additional requests.
+ * Validates code exists and subscription is active.
+ * Returns client info (code, name, color), all boards array, and rootBoardId.
+ * Increments accessCount and updates lastAccessAt.
+ */
+async function getAccessBoard(req, res) {
+  const code = req.swagger.params.code.value.toUpperCase();
+
+  try {
+    const now = new Date();
+    const client = await AccessClient.findOne({
+      code: code,
+      isActive: true,
+      subscriptionStart: { $lte: now },
+      subscriptionEnd: { $gte: now }
+    });
+
+    if (!client) {
+      return res.status(404).json({
+        message: 'Invalid or expired access code'
+      });
+    }
+
+    // Get ALL boards with this accessCode
+    const boards = await Board.find({ accessCode: code });
+
+    if (!boards || boards.length === 0) {
+      return res.status(404).json({
+        message: 'No boards available for this code'
+      });
+    }
+
+    // Verify the rootBoard exists
+    const rootBoard = boards.find(
+      b => b._id.toString() === client.rootBoardId.toString()
+    );
+    if (!rootBoard) {
+      return res.status(404).json({
+        message: 'Root board not found'
+      });
+    }
+
+    // Track access analytics
+    client.accessCount += 1;
+    client.lastAccessAt = new Date();
+    await client.save();
+
+    return res.status(200).json({
+      client: {
+        code: client.code,
+        name: client.clientName,
+        color: client.brandColor
+      },
+      boards: boards.map(b => b.toJSON()),
+      rootBoardId: client.rootBoardId.toString()
+    });
+  } catch (err) {
+    return res.status(500).json({
+      message: 'Error getting boards',
+      error: err.message
+    });
+  }
+}

--- a/api/controllers/access.js
+++ b/api/controllers/access.js
@@ -80,8 +80,10 @@ async function getAccessBoard(req, res) {
       });
     }
 
-    // Get ALL boards with this accessCode
-    const boards = await Board.find({ accessCode: code });
+    // Get ALL boards with this accessCode (exclude PII fields for public endpoint)
+    const boards = await Board.find({ accessCode: code }).select(
+      '-email -author'
+    );
 
     if (!boards || boards.length === 0) {
       return res.status(404).json({
@@ -99,10 +101,14 @@ async function getAccessBoard(req, res) {
       });
     }
 
-    // Track access analytics
-    client.accessCount += 1;
-    client.lastAccessAt = new Date();
-    await client.save();
+    // Track access analytics atomically to avoid lost updates under concurrency
+    await AccessClient.updateOne(
+      { _id: client._id },
+      {
+        $inc: { accessCount: 1 },
+        $set: { lastAccessAt: new Date() }
+      }
+    );
 
     return res.status(200).json({
       client: {

--- a/api/models/AccessClient.js
+++ b/api/models/AccessClient.js
@@ -3,35 +3,6 @@
 const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
 
-const accessPointSchema = new Schema(
-  {
-    code: {
-      type: String,
-      required: true,
-      trim: true,
-      uppercase: true
-    },
-    rootBoardId: {
-      type: Schema.Types.ObjectId,
-      ref: 'Board',
-      required: true
-    },
-    isListedInApp: {
-      type: Boolean,
-      default: true
-    },
-    accessCount: {
-      type: Number,
-      default: 0
-    },
-    lastAccessAt: {
-      type: Date,
-      default: null
-    }
-  },
-  { _id: true }
-);
-
 const ACCESS_CLIENT_SCHEMA_DEFINITION = {
   slug: {
     type: String,
@@ -71,8 +42,7 @@ const ACCESS_CLIENT_SCHEMA_DEFINITION = {
     type: Schema.Types.ObjectId,
     ref: 'User',
     required: true
-  },
-  accessPoints: [accessPointSchema]
+  }
 };
 
 const ACCESS_CLIENT_SCHEMA_OPTIONS = {

--- a/api/models/AccessClient.js
+++ b/api/models/AccessClient.js
@@ -1,0 +1,86 @@
+'use strict';
+
+const mongoose = require('mongoose');
+const Schema = mongoose.Schema;
+
+const ACCESS_CLIENT_SCHEMA_DEFINITION = {
+  code: {
+    type: String,
+    unique: true,
+    required: true,
+    trim: true,
+    uppercase: true
+  },
+  clientName: {
+    type: String,
+    required: true,
+    trim: true
+  },
+  clientContact: {
+    type: String,
+    trim: true
+  },
+  brandColor: {
+    type: String
+  },
+  rootBoardId: {
+    type: Schema.Types.ObjectId,
+    ref: 'Board',
+    required: true
+  },
+  isActive: {
+    type: Boolean,
+    default: true
+  },
+  isListedInApp: {
+    type: Boolean,
+    default: true
+  },
+  subscriptionStart: {
+    type: Date,
+    required: true
+  },
+  subscriptionEnd: {
+    type: Date,
+    required: true
+  },
+  accessCount: {
+    type: Number,
+    default: 0
+  },
+  lastAccessAt: {
+    type: Date
+  },
+  createdBy: {
+    type: Schema.Types.ObjectId,
+    ref: 'User',
+    required: true
+  }
+};
+
+const ACCESS_CLIENT_SCHEMA_OPTIONS = {
+  timestamps: true,
+  toObject: {
+    virtuals: true
+  },
+  toJSON: {
+    virtuals: true,
+    versionKey: false,
+    transform: function (doc, ret) {
+      ret.id = ret._id;
+      delete ret._id;
+    }
+  }
+};
+
+const accessClientSchema = new Schema(
+  ACCESS_CLIENT_SCHEMA_DEFINITION,
+  ACCESS_CLIENT_SCHEMA_OPTIONS
+);
+
+accessClientSchema.index({ code: 1 }, { unique: true });
+accessClientSchema.index({ isActive: 1, isListedInApp: 1 });
+
+const AccessClient = mongoose.model('AccessClient', accessClientSchema);
+
+module.exports = AccessClient;

--- a/api/models/AccessClient.js
+++ b/api/models/AccessClient.js
@@ -17,7 +17,11 @@ const ACCESS_CLIENT_SCHEMA_DEFINITION = {
       required: true,
       trim: true
     },
-    contact: {
+    email: {
+      type: String,
+      trim: true
+    },
+    phone: {
       type: String,
       trim: true
     }

--- a/api/models/AccessClient.js
+++ b/api/models/AccessClient.js
@@ -3,36 +3,59 @@
 const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
 
+const accessPointSchema = new Schema(
+  {
+    code: {
+      type: String,
+      required: true,
+      trim: true,
+      uppercase: true
+    },
+    rootBoardId: {
+      type: Schema.Types.ObjectId,
+      ref: 'Board',
+      required: true
+    },
+    isListedInApp: {
+      type: Boolean,
+      default: true
+    },
+    accessCount: {
+      type: Number,
+      default: 0
+    },
+    lastAccessAt: {
+      type: Date,
+      default: null
+    }
+  },
+  { _id: true }
+);
+
 const ACCESS_CLIENT_SCHEMA_DEFINITION = {
-  code: {
+  slug: {
     type: String,
     unique: true,
     required: true,
     trim: true,
-    uppercase: true
+    lowercase: true
   },
-  clientName: {
-    type: String,
-    required: true,
-    trim: true
-  },
-  clientContact: {
-    type: String,
-    trim: true
+  client: {
+    name: {
+      type: String,
+      required: true,
+      trim: true
+    },
+    contact: {
+      type: String,
+      trim: true
+    }
   },
   brandColor: {
-    type: String
-  },
-  rootBoardId: {
-    type: Schema.Types.ObjectId,
-    ref: 'Board',
-    required: true
+    type: String,
+    default: '#1976d2'
   },
   isActive: {
-    type: Boolean,
-    default: true
-  },
-  isListedInApp: {
     type: Boolean,
     default: true
   },
@@ -44,18 +67,12 @@ const ACCESS_CLIENT_SCHEMA_DEFINITION = {
     type: Date,
     required: true
   },
-  accessCount: {
-    type: Number,
-    default: 0
-  },
-  lastAccessAt: {
-    type: Date
-  },
   createdBy: {
     type: Schema.Types.ObjectId,
     ref: 'User',
     required: true
-  }
+  },
+  accessPoints: [accessPointSchema]
 };
 
 const ACCESS_CLIENT_SCHEMA_OPTIONS = {
@@ -66,7 +83,7 @@ const ACCESS_CLIENT_SCHEMA_OPTIONS = {
   toJSON: {
     virtuals: true,
     versionKey: false,
-    transform: function (doc, ret) {
+    transform: function(doc, ret) {
       ret.id = ret._id;
       delete ret._id;
     }
@@ -77,8 +94,6 @@ const accessClientSchema = new Schema(
   ACCESS_CLIENT_SCHEMA_DEFINITION,
   ACCESS_CLIENT_SCHEMA_OPTIONS
 );
-
-accessClientSchema.index({ isActive: 1, isListedInApp: 1 });
 
 const AccessClient = mongoose.model('AccessClient', accessClientSchema);
 

--- a/api/models/AccessClient.js
+++ b/api/models/AccessClient.js
@@ -78,7 +78,6 @@ const accessClientSchema = new Schema(
   ACCESS_CLIENT_SCHEMA_OPTIONS
 );
 
-accessClientSchema.index({ code: 1 }, { unique: true });
 accessClientSchema.index({ isActive: 1, isListedInApp: 1 });
 
 const AccessClient = mongoose.model('AccessClient', accessClientSchema);

--- a/api/models/AccessPoint.js
+++ b/api/models/AccessPoint.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const mongoose = require('mongoose');
+const Schema = mongoose.Schema;
+
+const ACCESS_POINT_SCHEMA_DEFINITION = {
+  code: {
+    type: String,
+    required: true,
+    trim: true,
+    uppercase: true,
+    unique: true,
+    index: true
+  },
+  accessClient: {
+    type: Schema.Types.ObjectId,
+    ref: 'AccessClient',
+    required: true
+  },
+  rootBoardId: {
+    type: Schema.Types.ObjectId,
+    ref: 'Board',
+    required: true
+  },
+  viewsCount: {
+    type: Number,
+    default: 0
+  },
+  lastAccessAt: {
+    type: Date,
+    default: null
+  }
+};
+
+const ACCESS_POINT_SCHEMA_OPTIONS = {
+  timestamps: true,
+  toObject: {
+    virtuals: true
+  },
+  toJSON: {
+    virtuals: true,
+    versionKey: false,
+    transform: function(doc, ret) {
+      ret.id = ret._id;
+      delete ret._id;
+    }
+  }
+};
+
+const accessPointSchema = new Schema(
+  ACCESS_POINT_SCHEMA_DEFINITION,
+  ACCESS_POINT_SCHEMA_OPTIONS
+);
+
+const AccessPoint = mongoose.model('AccessPoint', accessPointSchema);
+
+module.exports = AccessPoint;

--- a/api/models/AccessPoint.js
+++ b/api/models/AccessPoint.js
@@ -29,6 +29,11 @@ const ACCESS_POINT_SCHEMA_DEFINITION = {
   lastAccessAt: {
     type: Date,
     default: null
+  },
+  linkedBoardsIds: {
+    type: [Schema.Types.ObjectId],
+    ref: 'Board',
+    default: []
   }
 };
 

--- a/api/models/Board.js
+++ b/api/models/Board.js
@@ -67,7 +67,9 @@ const BOARD_SCHEMA_DEFINITION = {
     type: String,
     trim: true,
     uppercase: true,
-    default: null
+    default: null,
+    unique: true,
+    sparse: true
   }
 };
 
@@ -87,8 +89,8 @@ const BOARD_SCHEMA_OPTIONS = {
 
 const boardSchema = new Schema(BOARD_SCHEMA_DEFINITION, BOARD_SCHEMA_OPTIONS);
 
-// Sparse index skips documents where accessPointCode is null/missing, optimizing queries for Access boards
-boardSchema.index({ accessPointCode: 1 }, { sparse: true });
+// Sparse unique index skips documents where accessPointCode is null/missing, enforcing uniqueness only for set values
+boardSchema.index({ accessPointCode: 1 }, { sparse: true, unique: true });
 
 const validatePresenceOf = value => value && value.length;
 

--- a/api/models/Board.js
+++ b/api/models/Board.js
@@ -63,10 +63,11 @@ const BOARD_SCHEMA_DEFINITION = {
     default: false
   },
   grid: {},
-  accessCode: {
+  accessPointCode: {
     type: String,
     trim: true,
-    uppercase: true
+    uppercase: true,
+    default: null
   }
 };
 
@@ -86,8 +87,8 @@ const BOARD_SCHEMA_OPTIONS = {
 
 const boardSchema = new Schema(BOARD_SCHEMA_DEFINITION, BOARD_SCHEMA_OPTIONS);
 
-// Sparse index skips documents where accessCode is missing, optimizing queries for Access boards
-boardSchema.index({ accessCode: 1 }, { sparse: true });
+// Sparse index skips documents where accessPointCode is null/missing, optimizing queries for Access boards
+boardSchema.index({ accessPointCode: 1 }, { sparse: true });
 
 const validatePresenceOf = value => value && value.length;
 

--- a/api/models/Board.js
+++ b/api/models/Board.js
@@ -67,9 +67,7 @@ const BOARD_SCHEMA_DEFINITION = {
     type: String,
     trim: true,
     uppercase: true,
-    default: null,
-    unique: true,
-    sparse: true
+    default: null
   }
 };
 

--- a/test/controllers/board.js
+++ b/test/controllers/board.js
@@ -252,11 +252,11 @@ describe('Board API calls', function () {
     });
   });
 
-  describe('accessCode field behavior', function () {
-    it('should normalize accessCode to uppercase when creating a board', async function () {
+  describe('accessPointCode field behavior', function () {
+    it('should normalize accessPointCode to uppercase when creating a board', async function () {
       const boardWithAccessCode = {
         ...helper.boardData,
-        accessCode: 'cafe01'
+        accessPointCode: 'cafe01'
       };
       const res = await request(server)
         .post('/board')
@@ -266,14 +266,14 @@ describe('Board API calls', function () {
         .expect('Content-Type', /json/)
         .expect(200);
 
-      res.body.should.have.property('accessCode');
-      res.body.accessCode.should.equal('CAFE01');
+      res.body.should.have.property('accessPointCode');
+      res.body.accessPointCode.should.equal('CAFE01');
     });
 
-    it('should trim whitespace from accessCode', async function () {
+    it('should trim whitespace from accessPointCode', async function () {
       const boardWithAccessCode = {
         ...helper.boardData,
-        accessCode: '  test01  '
+        accessPointCode: '  test01  '
       };
       const res = await request(server)
         .post('/board')
@@ -283,13 +283,13 @@ describe('Board API calls', function () {
         .expect('Content-Type', /json/)
         .expect(200);
 
-      res.body.should.have.property('accessCode');
-      res.body.accessCode.should.equal('TEST01');
+      res.body.should.have.property('accessPointCode');
+      res.body.accessPointCode.should.equal('TEST01');
     });
 
-    it('should not include accessCode when not provided', async function () {
+    it('should default accessPointCode to null when not provided', async function () {
       const boardWithoutAccessCode = { ...helper.boardData };
-      delete boardWithoutAccessCode.accessCode;
+      delete boardWithoutAccessCode.accessPointCode;
 
       const res = await request(server)
         .post('/board')
@@ -299,15 +299,15 @@ describe('Board API calls', function () {
         .expect('Content-Type', /json/)
         .expect(200);
 
-      res.body.should.not.have.property('accessCode');
+      res.body.accessPointCode.should.equal(null);
     });
 
-    it('should update accessCode on an existing board', async function () {
+    it('should update accessPointCode on an existing board', async function () {
       const boardId = await helper.createMochaBoard(server, user.token);
 
       const updateData = {
         ...helper.boardData,
-        accessCode: 'updated01'
+        accessPointCode: 'updated01'
       };
       const res = await request(server)
         .put('/board/' + boardId)
@@ -317,14 +317,14 @@ describe('Board API calls', function () {
         .expect('Content-Type', /json/)
         .expect(200);
 
-      res.body.should.have.property('accessCode');
-      res.body.accessCode.should.equal('UPDATED01');
+      res.body.should.have.property('accessPointCode');
+      res.body.accessPointCode.should.equal('UPDATED01');
     });
 
-    it('should return accessCode in GET response when set', async function () {
+    it('should return accessPointCode in GET response when set', async function () {
       const boardWithAccessCode = {
         ...helper.boardData,
-        accessCode: 'gettest01'
+        accessPointCode: 'gettest01'
       };
       const createRes = await request(server)
         .post('/board')
@@ -343,8 +343,8 @@ describe('Board API calls', function () {
         .expect('Content-Type', /json/)
         .expect(200);
 
-      getRes.body.should.have.property('accessCode');
-      getRes.body.accessCode.should.equal('GETTEST01');
+      getRes.body.should.have.property('accessPointCode');
+      getRes.body.accessPointCode.should.equal('GETTEST01');
     });
   });
 


### PR DESCRIPTION
Created `api/controllers/access.js` - Access controller with public endpoints for the Cboard Access feature.

Endpoints implemented
1. GET `/access/clients` - `getClients()`
   - Lists active companies for Cboard Access listing in the app
   - Filters by valid subscription dates
   - Populates root board basic info (name, caption, tiles count)
   - Returns sorted by clientName
   
 2. GET `/access/:code` - `getAccessBoard()`
   - Gets ALL boards for an access code in a single request
   - Validates code exists and subscription is active
   - Returns: client info (code, name, color), all boards array, and `rootBoardId`
   - Tracks analytics: increments `viewsCount` and updates `lastAccessAt`
   - Enables instant frontend navigation without additional requests

  Error handling
  - 404 for invalid/expired access codes
  - 404 when no boards available for a code
  - 404 when root board not found
  - 500 for server errors with descriptive messages

  ---

  ## Summary
  - Add Access controller with public endpoints for Cboard Access feature
  - Implement `getClients` to list active companies with valid subscriptions
  - Implement `getAccessBoard` to fetch all boards for an access code in a single request, enabling instant navigation
  - Include analytics tracking (access count and last access timestamp)

Closes #442 