### PR TITLE
Access controller with admin endpoints

### DIFF
--- a/api/controllers/access.js
+++ b/api/controllers/access.js
@@ -176,7 +176,10 @@ async function createAccessClient(req, res) {
     await client.save();
 
     // Mark the boards with the accessCode
-    const allBoardIds = boardIds || [rootBoardId];
+    // Ensure rootBoardId is always included even if boardIds is empty array
+    const allBoardIds = boardIds && boardIds.length > 0 
+      ? [...new Set([rootBoardId.toString(), ...boardIds.map(id => id.toString())])]
+      : [rootBoardId];
     await Board.updateMany(
       { _id: { $in: allBoardIds } },
       { $set: { accessCode: code.toUpperCase() } }
@@ -207,23 +210,32 @@ async function listAccessClients(req, res) {
       .populate('createdBy', 'name email')
       .sort({ createdAt: -1 });
 
-    // For each client, count associated boards
-    const result = await Promise.all(
-      clients.map(async client => {
-        const boardCount = await Board.countDocuments({
-          accessCode: client.code
-        });
+    // Precompute board counts for all clients in a single query to avoid N+1
+    const accessCodes = clients.map(client => client.code);
+    const boardCounts = await Board.aggregate([
+      { $match: { accessCode: { $in: accessCodes } } },
+      { $group: { _id: '$accessCode', count: { $sum: 1 } } }
+    ]);
 
-        return {
-          ...client.toJSON(),
-          boardCount,
-          isExpired: client.subscriptionEnd < new Date(),
-          daysUntilExpiry: Math.ceil(
-            (client.subscriptionEnd - new Date()) / (1000 * 60 * 60 * 24)
-          )
-        };
-      })
-    );
+    const boardCountMap = boardCounts.reduce((map, entry) => {
+      map[entry._id] = entry.count;
+      return map;
+    }, {});
+
+    const now = new Date();
+    const result = clients.map(client => {
+      const boardCount = boardCountMap[client.code] || 0;
+      const daysUntilExpiry = Math.ceil(
+        (client.subscriptionEnd - now) / (1000 * 60 * 60 * 24)
+      );
+
+      return {
+        ...client.toJSON(),
+        boardCount,
+        isExpired: client.subscriptionEnd < now,
+        daysUntilExpiry: Math.max(0, daysUntilExpiry)
+      };
+    });
 
     return res.status(200).json({
       total: result.length,
@@ -295,6 +307,11 @@ async function getAccessClientStats(req, res) {
 
     const boards = await Board.find({ accessCode: code }, { name: 1, tiles: 1 });
 
+    const now = new Date();
+    const daysUntilExpiry = Math.ceil(
+      (client.subscriptionEnd - now) / (1000 * 60 * 60 * 24)
+    );
+
     return res.status(200).json({
       client: client.toJSON(),
       stats: {
@@ -306,10 +323,8 @@ async function getAccessClientStats(req, res) {
           name: b.name,
           tilesCount: b.tiles?.length || 0
         })),
-        daysUntilExpiry: Math.ceil(
-          (client.subscriptionEnd - new Date()) / (1000 * 60 * 60 * 24)
-        ),
-        isExpired: client.subscriptionEnd < new Date()
+        daysUntilExpiry: Math.max(0, daysUntilExpiry),
+        isExpired: client.subscriptionEnd < now
       }
     });
   } catch (err) {

--- a/api/controllers/access.js
+++ b/api/controllers/access.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const AccessClient = require('../models/AccessClient');
+const AccessPoint = require('../models/AccessPoint');
 const Board = require('../models/Board');
 
 module.exports = {
@@ -10,37 +11,45 @@ module.exports = {
 
 /**
  * GET /access/clients
- * Lists active companies for Cboard Access listing in the app.
- * Returns clients where isActive=true, isListedInApp=true, and subscription is valid.
- * Populates rootBoard basic info (name, caption, tiles count).
- * Sorted by clientName.
+ * Lists all active clients with valid subscriptions and their access points.
+ * Returns each client with its access points and root board basic info.
+ * Sorted by client name.
  */
 async function getClients(req, res) {
   try {
     const now = new Date();
     const clients = await AccessClient.find({
       isActive: true,
-      isListedInApp: true,
       subscriptionStart: { $lte: now },
       subscriptionEnd: { $gte: now }
+    }).select('slug client brandColor');
+
+    const accessPoints = await AccessPoint.find({
+      accessClient: { $in: clients.map(c => c._id) }
     })
       .populate('rootBoardId', 'name caption tiles')
-      .select('code clientName brandColor rootBoardId')
-      .sort({ clientName: 1 });
+      .select('code rootBoardId accessClient');
 
-    const result = clients.map(client => ({
-      code: client.code,
-      clientName: client.clientName,
-      brandColor: client.brandColor,
-      rootBoard: client.rootBoardId
-        ? {
-            id: client.rootBoardId._id,
-            name: client.rootBoardId.name,
-            caption: client.rootBoardId.caption,
-            tilesCount: client.rootBoardId.tiles?.length || 0
-          }
-        : null
-    }));
+    const result = clients
+      .map(client => ({
+        slug: client.slug,
+        clientName: client.client.name,
+        brandColor: client.brandColor,
+        accessPoints: accessPoints
+          .filter(ap => ap.accessClient.toString() === client._id.toString())
+          .map(ap => ({
+            code: ap.code,
+            rootBoard: ap.rootBoardId
+              ? {
+                  id: ap.rootBoardId._id,
+                  name: ap.rootBoardId.name,
+                  caption: ap.rootBoardId.caption,
+                  tilesCount: ap.rootBoardId.tiles?.length || 0
+                }
+              : null
+          }))
+      }))
+      .sort((a, b) => a.clientName.localeCompare(b.clientName));
 
     return res.status(200).json({
       total: result.length,
@@ -58,32 +67,41 @@ async function getClients(req, res) {
  * GET /access/:code
  * Gets ALL boards for an access code in a single request.
  * This enables instant frontend navigation without additional requests.
- * Validates code exists and subscription is active.
- * Returns client info (code, name, color), all boards array, and rootBoardId.
- * Increments accessCount and updates lastAccessAt.
+ * Validates code exists and client subscription is active.
+ * Returns client info (slug, name, color), all boards array, and rootBoardId.
+ * Increments viewsCount and updates lastAccessAt on the AccessPoint.
  */
 async function getAccessBoard(req, res) {
   const code = req.swagger.params.code.value.toUpperCase();
 
   try {
     const now = new Date();
-    const client = await AccessClient.findOne({
-      code: code,
-      isActive: true,
-      subscriptionStart: { $lte: now },
-      subscriptionEnd: { $gte: now }
-    });
+    const accessPoint = await AccessPoint.findOne({ code }).populate(
+      'accessClient'
+    );
 
-    if (!client) {
+    if (!accessPoint) {
+      return res.status(404).json({
+        message: 'Invalid access code'
+      });
+    }
+
+    const client = accessPoint.accessClient;
+    if (
+      !client ||
+      !client.isActive ||
+      client.subscriptionStart > now ||
+      client.subscriptionEnd < now
+    ) {
       return res.status(404).json({
         message: 'Invalid or expired access code'
       });
     }
 
-    // Get ALL boards with this accessCode (exclude PII fields for public endpoint)
-    const boards = await Board.find({ accessCode: code }).select(
-      '-email -author'
-    );
+    // Fetch all linked boards (exclude PII fields for public endpoint)
+    const boards = await Board.find({
+      _id: { $in: accessPoint.linkedBoardsIds }
+    }).select('-email -author');
 
     if (!boards || boards.length === 0) {
       return res.status(404).json({
@@ -91,9 +109,9 @@ async function getAccessBoard(req, res) {
       });
     }
 
-    // Verify the rootBoard exists
+    // Verify the rootBoard exists among the linked boards
     const rootBoard = boards.find(
-      b => b._id.toString() === client.rootBoardId.toString()
+      b => b._id.toString() === accessPoint.rootBoardId.toString()
     );
     if (!rootBoard) {
       return res.status(404).json({
@@ -102,22 +120,22 @@ async function getAccessBoard(req, res) {
     }
 
     // Track access analytics atomically to avoid lost updates under concurrency
-    await AccessClient.updateOne(
-      { _id: client._id },
+    await AccessPoint.updateOne(
+      { _id: accessPoint._id },
       {
-        $inc: { accessCount: 1 },
+        $inc: { viewsCount: 1 },
         $set: { lastAccessAt: new Date() }
       }
     );
 
     return res.status(200).json({
       client: {
-        code: client.code,
-        name: client.clientName,
+        code: client.slug,
+        name: client.client.name,
         color: client.brandColor
       },
       boards: boards.map(b => b.toJSON()),
-      rootBoardId: client.rootBoardId.toString()
+      rootBoardId: accessPoint.rootBoardId.toString()
     });
   } catch (err) {
     return res.status(500).json({

--- a/api/controllers/access.js
+++ b/api/controllers/access.js
@@ -5,7 +5,11 @@ const Board = require('../models/Board');
 
 module.exports = {
   getClients: getClients,
-  getAccessBoard: getAccessBoard
+  getAccessBoard: getAccessBoard,
+  createAccessClient: createAccessClient,
+  listAccessClients: listAccessClients,
+  updateAccessClient: updateAccessClient,
+  getAccessClientStats: getAccessClientStats
 };
 
 /**
@@ -122,6 +126,195 @@ async function getAccessBoard(req, res) {
   } catch (err) {
     return res.status(500).json({
       message: 'Error getting boards',
+      error: err.message
+    });
+  }
+}
+
+// ============================================
+// ADMIN ENDPOINTS
+// ============================================
+
+/**
+ * POST /api/admin/access-clients
+ * Creates a new Access client.
+ * Requires admin authentication (enforced by Swagger middleware).
+ * Creates AccessClient and updates boards with accessCode.
+ * Validates rootBoardId exists.
+ */
+async function createAccessClient(req, res) {
+  const {
+    code,
+    clientName,
+    clientContact,
+    brandColor,
+    rootBoardId,
+    subscriptionStart,
+    subscriptionEnd,
+    boardIds // Array of board IDs to associate
+  } = req.body;
+
+  try {
+    // Verify that the root board exists
+    const rootBoard = await Board.findById(rootBoardId);
+    if (!rootBoard) {
+      return res.status(404).json({ message: 'Root board not found' });
+    }
+
+    // Create the client
+    const client = new AccessClient({
+      code: code.toUpperCase(),
+      clientName,
+      clientContact,
+      brandColor,
+      rootBoardId,
+      subscriptionStart: new Date(subscriptionStart),
+      subscriptionEnd: new Date(subscriptionEnd),
+      createdBy: req.user.id
+    });
+
+    await client.save();
+
+    // Mark the boards with the accessCode
+    const allBoardIds = boardIds || [rootBoardId];
+    await Board.updateMany(
+      { _id: { $in: allBoardIds } },
+      { $set: { accessCode: code.toUpperCase() } }
+    );
+
+    return res.status(201).json(client.toJSON());
+  } catch (err) {
+    if (err.code === 11000) {
+      return res.status(409).json({ message: 'Code already exists' });
+    }
+    return res.status(500).json({
+      message: 'Error creating client',
+      error: err.message
+    });
+  }
+}
+
+/**
+ * GET /api/admin/access-clients
+ * Lists all Access clients with stats.
+ * Returns all clients with board counts, expiry status.
+ * Populates rootBoard and createdBy.
+ */
+async function listAccessClients(req, res) {
+  try {
+    const clients = await AccessClient.find()
+      .populate('rootBoardId', 'name')
+      .populate('createdBy', 'name email')
+      .sort({ createdAt: -1 });
+
+    // For each client, count associated boards
+    const result = await Promise.all(
+      clients.map(async client => {
+        const boardCount = await Board.countDocuments({
+          accessCode: client.code
+        });
+
+        return {
+          ...client.toJSON(),
+          boardCount,
+          isExpired: client.subscriptionEnd < new Date(),
+          daysUntilExpiry: Math.ceil(
+            (client.subscriptionEnd - new Date()) / (1000 * 60 * 60 * 24)
+          )
+        };
+      })
+    );
+
+    return res.status(200).json({
+      total: result.length,
+      data: result
+    });
+  } catch (err) {
+    return res.status(500).json({
+      message: 'Error listing clients',
+      error: err.message
+    });
+  }
+}
+
+/**
+ * PUT /api/admin/access-clients/:code
+ * Updates an Access client.
+ * Allowed fields: isActive, isListedInApp, subscription dates, branding.
+ */
+async function updateAccessClient(req, res) {
+  const code = req.swagger.params.code.value.toUpperCase();
+  const updates = req.body;
+
+  try {
+    const client = await AccessClient.findOne({ code });
+
+    if (!client) {
+      return res.status(404).json({ message: 'Client not found' });
+    }
+
+    // Updatable fields
+    if (updates.isActive !== undefined) client.isActive = updates.isActive;
+    if (updates.isListedInApp !== undefined)
+      client.isListedInApp = updates.isListedInApp;
+    if (updates.subscriptionStart)
+      client.subscriptionStart = new Date(updates.subscriptionStart);
+    if (updates.subscriptionEnd)
+      client.subscriptionEnd = new Date(updates.subscriptionEnd);
+    if (updates.clientName) client.clientName = updates.clientName;
+    if (updates.clientContact) client.clientContact = updates.clientContact;
+    if (updates.brandColor) client.brandColor = updates.brandColor;
+
+    await client.save();
+
+    return res.status(200).json(client.toJSON());
+  } catch (err) {
+    return res.status(500).json({
+      message: 'Error updating client',
+      error: err.message
+    });
+  }
+}
+
+/**
+ * GET /api/admin/access-clients/:code/stats
+ * Gets detailed statistics for an Access client.
+ * Returns client info, access counts, board list with tile counts.
+ */
+async function getAccessClientStats(req, res) {
+  const code = req.swagger.params.code.value.toUpperCase();
+
+  try {
+    const client = await AccessClient.findOne({ code })
+      .populate('rootBoardId', 'name tiles')
+      .populate('createdBy', 'name email');
+
+    if (!client) {
+      return res.status(404).json({ message: 'Client not found' });
+    }
+
+    const boards = await Board.find({ accessCode: code }, { name: 1, tiles: 1 });
+
+    return res.status(200).json({
+      client: client.toJSON(),
+      stats: {
+        totalAccesses: client.accessCount,
+        lastAccessAt: client.lastAccessAt,
+        boardCount: boards.length,
+        boards: boards.map(b => ({
+          id: b._id,
+          name: b.name,
+          tilesCount: b.tiles?.length || 0
+        })),
+        daysUntilExpiry: Math.ceil(
+          (client.subscriptionEnd - new Date()) / (1000 * 60 * 60 * 24)
+        ),
+        isExpired: client.subscriptionEnd < new Date()
+      }
+    });
+  } catch (err) {
+    return res.status(500).json({
+      message: 'Error getting client statistics',
       error: err.message
     });
   }

--- a/api/controllers/access.js
+++ b/api/controllers/access.js
@@ -1,0 +1,122 @@
+'use strict';
+
+const AccessClient = require('../models/AccessClient');
+const Board = require('../models/Board');
+
+module.exports = {
+  getClients: getClients,
+  getAccessBoard: getAccessBoard
+};
+
+/**
+ * GET /access/clients
+ * Lists active companies for Cboard Access listing in the app.
+ * Returns clients where isActive=true, isListedInApp=true, and subscription is valid.
+ * Populates rootBoard basic info (name, caption, tiles count).
+ * Sorted by clientName.
+ */
+async function getClients(req, res) {
+  try {
+    const now = new Date();
+    const clients = await AccessClient.find({
+      isActive: true,
+      isListedInApp: true,
+      subscriptionStart: { $lte: now },
+      subscriptionEnd: { $gte: now }
+    })
+      .populate('rootBoardId', 'name caption tiles')
+      .select('code clientName brandColor rootBoardId')
+      .sort({ clientName: 1 });
+
+    const result = clients.map(client => ({
+      code: client.code,
+      clientName: client.clientName,
+      brandColor: client.brandColor,
+      rootBoard: client.rootBoardId
+        ? {
+            id: client.rootBoardId._id,
+            name: client.rootBoardId.name,
+            caption: client.rootBoardId.caption,
+            tilesCount: client.rootBoardId.tiles?.length || 0
+          }
+        : null
+    }));
+
+    return res.status(200).json({
+      total: result.length,
+      data: result
+    });
+  } catch (err) {
+    return res.status(500).json({
+      message: 'Error listing clients',
+      error: err.message
+    });
+  }
+}
+
+/**
+ * GET /access/:code
+ * Gets ALL boards for an access code in a single request.
+ * This enables instant frontend navigation without additional requests.
+ * Validates code exists and subscription is active.
+ * Returns client info (code, name, color), all boards array, and rootBoardId.
+ * Increments accessCount and updates lastAccessAt.
+ */
+async function getAccessBoard(req, res) {
+  const code = req.swagger.params.code.value.toUpperCase();
+
+  try {
+    const now = new Date();
+    const client = await AccessClient.findOne({
+      code: code,
+      isActive: true,
+      subscriptionStart: { $lte: now },
+      subscriptionEnd: { $gte: now }
+    });
+
+    if (!client) {
+      return res.status(404).json({
+        message: 'Invalid or expired access code'
+      });
+    }
+
+    // Get ALL boards with this accessCode
+    const boards = await Board.find({ accessCode: code });
+
+    if (!boards || boards.length === 0) {
+      return res.status(404).json({
+        message: 'No boards available for this code'
+      });
+    }
+
+    // Verify the rootBoard exists
+    const rootBoard = boards.find(
+      b => b._id.toString() === client.rootBoardId.toString()
+    );
+    if (!rootBoard) {
+      return res.status(404).json({
+        message: 'Root board not found'
+      });
+    }
+
+    // Track access analytics
+    client.accessCount += 1;
+    client.lastAccessAt = new Date();
+    await client.save();
+
+    return res.status(200).json({
+      client: {
+        code: client.code,
+        name: client.clientName,
+        color: client.brandColor
+      },
+      boards: boards.map(b => b.toJSON()),
+      rootBoardId: client.rootBoardId.toString()
+    });
+  } catch (err) {
+    return res.status(500).json({
+      message: 'Error getting boards',
+      error: err.message
+    });
+  }
+}

--- a/api/controllers/access.js
+++ b/api/controllers/access.js
@@ -10,8 +10,43 @@ module.exports = {
   createAccessClient: createAccessClient,
   listAccessClients: listAccessClients,
   updateAccessClient: updateAccessClient,
+  updateAccessPoint: updateAccessPoint,
   getAccessClientStats: getAccessClientStats
 };
+
+/**
+ * Recursively discovers all boards reachable from a root board via tile.loadBoard references.
+ * The visited Set is shared across all recursive calls (passed by reference), so any board
+ * already discovered is skipped immediately — this prevents infinite loops from tiles that
+ * navigate back to a parent board (e.g. a "home" tile).
+ * @param {string|ObjectId} rootBoardId - Starting board ID
+ * @param {Set<string>} visited - Shared set of already-visited IDs (prevents cycles)
+ */
+async function discoverLinkedBoards(rootBoardId, visited) {
+  const id = rootBoardId.toString();
+  if (visited.has(id)) return; // Already discovered — skip to prevent cycles
+  visited.add(id);
+
+  const board = await Board.findById(id);
+  if (!board?.tiles) return;
+
+  for (const tile of board.tiles) {
+    if (tile.loadBoard) {
+      await discoverLinkedBoards(tile.loadBoard, visited);
+    }
+  }
+}
+
+/**
+ * Returns all board IDs reachable from rootBoardId, including rootBoardId itself.
+ * @param {string|ObjectId} rootBoardId
+ * @returns {Promise<string[]>}
+ */
+async function getAllLinkedBoardIds(rootBoardId) {
+  const visited = new Set();
+  await discoverLinkedBoards(rootBoardId, visited);
+  return [...visited];
+}
 
 /**
  * GET /access/clients
@@ -154,22 +189,22 @@ async function getAccessBoard(req, res) {
 // ============================================
 
 /**
- * POST /api/admin/access-clients
- * Creates a new Access client.
+ * POST /admin/access-clients
+ * Creates a new Access client and its first Access point.
  * Requires admin authentication (enforced by Swagger middleware).
- * Creates AccessClient and updates boards with accessCode.
+ * Creates AccessClient, creates AccessPoint, and updates boards with accessPointCode.
  * Validates rootBoardId exists.
  */
 async function createAccessClient(req, res) {
   const {
-    code,
+    slug,
     clientName,
     clientContact,
     brandColor,
     rootBoardId,
     subscriptionStart,
     subscriptionEnd,
-    boardIds // Array of board IDs to associate
+    accessPointCode
   } = req.body;
 
   try {
@@ -181,11 +216,9 @@ async function createAccessClient(req, res) {
 
     // Create the client
     const client = new AccessClient({
-      code: code.toUpperCase(),
-      clientName,
-      clientContact,
+      slug,
+      client: { name: clientName, contact: clientContact },
       brandColor,
-      rootBoardId,
       subscriptionStart: new Date(subscriptionStart),
       subscriptionEnd: new Date(subscriptionEnd),
       createdBy: req.user.id
@@ -193,20 +226,32 @@ async function createAccessClient(req, res) {
 
     await client.save();
 
-    // Mark the boards with the accessCode
-    // Ensure rootBoardId is always included even if boardIds is empty array
-    const allBoardIds = boardIds && boardIds.length > 0 
-      ? [...new Set([rootBoardId.toString(), ...boardIds.map(id => id.toString())])]
-      : [rootBoardId];
+    // Auto-discover all boards reachable from root via tile.loadBoard links
+    const linkedBoardIds = await getAllLinkedBoardIds(rootBoardId);
+
+    // Create the access point
+    const accessPoint = new AccessPoint({
+      code: accessPointCode.toUpperCase(),
+      accessClient: client._id,
+      rootBoardId,
+      linkedBoardsIds: linkedBoardIds
+    });
+
+    await accessPoint.save();
+
+    // Mark all discovered boards with the access point code
     await Board.updateMany(
-      { _id: { $in: allBoardIds } },
-      { $set: { accessCode: code.toUpperCase() } }
+      { _id: { $in: linkedBoardIds } },
+      { $set: { accessPointCode: accessPoint.code } }
     );
 
-    return res.status(201).json(client.toJSON());
+    return res.status(201).json({ ...client.toJSON(), accessPoint: accessPoint.toJSON() });
   } catch (err) {
     if (err.code === 11000) {
-      return res.status(409).json({ message: 'Code already exists' });
+      const isSlugDuplicate = err.message.includes('slug');
+      return res.status(409).json({
+        message: isSlugDuplicate ? 'Slug already exists' : 'Code already exists'
+      });
     }
     return res.status(500).json({
       message: 'Error creating client',
@@ -216,33 +261,31 @@ async function createAccessClient(req, res) {
 }
 
 /**
- * GET /api/admin/access-clients
+ * GET /admin/access-clients
  * Lists all Access clients with stats.
  * Returns all clients with board counts, expiry status.
- * Populates rootBoard and createdBy.
+ * Populates createdBy. Board count derived from AccessPoint.linkedBoardsIds.
  */
 async function listAccessClients(req, res) {
   try {
     const clients = await AccessClient.find()
-      .populate('rootBoardId', 'name')
       .populate('createdBy', 'name email')
       .sort({ createdAt: -1 });
 
-    // Precompute board counts for all clients in a single query to avoid N+1
-    const accessCodes = clients.map(client => client.code);
-    const boardCounts = await Board.aggregate([
-      { $match: { accessCode: { $in: accessCodes } } },
-      { $group: { _id: '$accessCode', count: { $sum: 1 } } }
-    ]);
+    // Fetch access points and sum linkedBoardsIds per client to avoid N+1
+    const clientIds = clients.map(c => c._id);
+    const accessPoints = await AccessPoint.find({ accessClient: { $in: clientIds } });
 
-    const boardCountMap = boardCounts.reduce((map, entry) => {
-      map[entry._id] = entry.count;
+    const apMap = accessPoints.reduce((map, ap) => {
+      const key = ap.accessClient.toString();
+      if (!map[key]) map[key] = 0;
+      map[key] += ap.linkedBoardsIds?.length || 0;
       return map;
     }, {});
 
     const now = new Date();
     const result = clients.map(client => {
-      const boardCount = boardCountMap[client.code] || 0;
+      const boardCount = apMap[client._id.toString()] || 0;
       const daysUntilExpiry = Math.ceil(
         (client.subscriptionEnd - now) / (1000 * 60 * 60 * 24)
       );
@@ -268,31 +311,28 @@ async function listAccessClients(req, res) {
 }
 
 /**
- * PUT /api/admin/access-clients/:code
+ * PUT /admin/access-clients/:slug
  * Updates an Access client.
- * Allowed fields: isActive, isListedInApp, subscription dates, branding.
+ * Allowed fields: isActive, subscription dates, branding, client name/contact.
  */
 async function updateAccessClient(req, res) {
-  const code = req.swagger.params.code.value.toUpperCase();
+  const slug = req.swagger.params.slug.value;
   const updates = req.body;
 
   try {
-    const client = await AccessClient.findOne({ code });
+    const client = await AccessClient.findOne({ slug });
 
     if (!client) {
       return res.status(404).json({ message: 'Client not found' });
     }
 
-    // Updatable fields
     if (updates.isActive !== undefined) client.isActive = updates.isActive;
-    if (updates.isListedInApp !== undefined)
-      client.isListedInApp = updates.isListedInApp;
     if (updates.subscriptionStart)
       client.subscriptionStart = new Date(updates.subscriptionStart);
     if (updates.subscriptionEnd)
       client.subscriptionEnd = new Date(updates.subscriptionEnd);
-    if (updates.clientName) client.clientName = updates.clientName;
-    if (updates.clientContact) client.clientContact = updates.clientContact;
+    if (updates.clientName) client.client.name = updates.clientName;
+    if (updates.clientContact) client.client.contact = updates.clientContact;
     if (updates.brandColor) client.brandColor = updates.brandColor;
 
     await client.save();
@@ -307,23 +347,35 @@ async function updateAccessClient(req, res) {
 }
 
 /**
- * GET /api/admin/access-clients/:code/stats
+ * GET /admin/access-clients/:slug/stats
  * Gets detailed statistics for an Access client.
- * Returns client info, access counts, board list with tile counts.
+ * Returns client info, access counts (from AccessPoints), board list with tile counts.
  */
 async function getAccessClientStats(req, res) {
-  const code = req.swagger.params.code.value.toUpperCase();
+  const slug = req.swagger.params.slug.value;
 
   try {
-    const client = await AccessClient.findOne({ code })
-      .populate('rootBoardId', 'name tiles')
+    const client = await AccessClient.findOne({ slug })
       .populate('createdBy', 'name email');
 
     if (!client) {
       return res.status(404).json({ message: 'Client not found' });
     }
 
-    const boards = await Board.find({ accessCode: code }, { name: 1, tiles: 1 });
+    const accessPoints = await AccessPoint.find({ accessClient: client._id });
+
+    // Collect unique board IDs across all access points
+    const allBoardIds = [
+      ...new Set(accessPoints.flatMap(ap => ap.linkedBoardsIds.map(id => id.toString())))
+    ];
+    const boards = await Board.find({ _id: { $in: allBoardIds } }, { name: 1, tiles: 1 });
+
+    const totalAccesses = accessPoints.reduce((sum, ap) => sum + (ap.viewsCount || 0), 0);
+    const lastAccessAt = accessPoints.reduce((latest, ap) => {
+      if (!ap.lastAccessAt) return latest;
+      if (!latest || ap.lastAccessAt > latest) return ap.lastAccessAt;
+      return latest;
+    }, null);
 
     const now = new Date();
     const daysUntilExpiry = Math.ceil(
@@ -333,8 +385,8 @@ async function getAccessClientStats(req, res) {
     return res.status(200).json({
       client: client.toJSON(),
       stats: {
-        totalAccesses: client.accessCount,
-        lastAccessAt: client.lastAccessAt,
+        totalAccesses,
+        lastAccessAt,
         boardCount: boards.length,
         boards: boards.map(b => ({
           id: b._id,
@@ -348,6 +400,52 @@ async function getAccessClientStats(req, res) {
   } catch (err) {
     return res.status(500).json({
       message: 'Error getting client statistics',
+      error: err.message
+    });
+  }
+}
+
+/**
+ * PUT /admin/access-points/:code
+ * Re-runs board discovery for an access point, updating its linkedBoardsIds.
+ * Optionally accepts a new rootBoardId to change the root and re-discover from there.
+ * Useful when the board structure has changed since the access point was created.
+ */
+async function updateAccessPoint(req, res) {
+  const code = req.swagger.params.code.value.toUpperCase();
+  const { rootBoardId } = req.body;
+
+  try {
+    const accessPoint = await AccessPoint.findOne({ code });
+    if (!accessPoint) {
+      return res.status(404).json({ message: 'Access point not found' });
+    }
+
+    const newRootBoardId = rootBoardId || accessPoint.rootBoardId;
+
+    // Verify root board exists
+    const rootBoard = await Board.findById(newRootBoardId);
+    if (!rootBoard) {
+      return res.status(404).json({ message: 'Root board not found' });
+    }
+
+    // Re-discover all boards reachable from root
+    const linkedBoardIds = await getAllLinkedBoardIds(newRootBoardId);
+
+    accessPoint.rootBoardId = newRootBoardId;
+    accessPoint.linkedBoardsIds = linkedBoardIds;
+    await accessPoint.save();
+
+    // Mark all discovered boards with this access point code
+    await Board.updateMany(
+      { _id: { $in: linkedBoardIds } },
+      { $set: { accessPointCode: code } }
+    );
+
+    return res.status(200).json(accessPoint.toJSON());
+  } catch (err) {
+    return res.status(500).json({
+      message: 'Error updating access point',
       error: err.message
     });
   }

--- a/api/controllers/access.js
+++ b/api/controllers/access.js
@@ -269,7 +269,7 @@ async function createAccessClient(req, res) {
 async function listAccessClients(req, res) {
   try {
     const clients = await AccessClient.find()
-      .populate('createdBy', 'name email')
+      .populate('createdBy', 'name email role')
       .sort({ createdAt: -1 });
 
     // Fetch access points and sum linkedBoardsIds per client to avoid N+1
@@ -356,7 +356,7 @@ async function getAccessClientStats(req, res) {
 
   try {
     const client = await AccessClient.findOne({ slug })
-      .populate('createdBy', 'name email');
+      .populate('createdBy', 'name email role');
 
     if (!client) {
       return res.status(404).json({ message: 'Client not found' });

--- a/api/controllers/access.js
+++ b/api/controllers/access.js
@@ -80,8 +80,10 @@ async function getAccessBoard(req, res) {
       });
     }
 
-    // Get ALL boards with this accessCode
-    const boards = await Board.find({ accessCode: code });
+    // Get ALL boards with this accessCode (exclude PII fields for public endpoint)
+    const boards = await Board.find({ accessCode: code }).select(
+      '-email -author'
+    );
 
     if (!boards || boards.length === 0) {
       return res.status(404).json({
@@ -99,10 +101,14 @@ async function getAccessBoard(req, res) {
       });
     }
 
-    // Track access analytics
-    client.accessCount += 1;
-    client.lastAccessAt = new Date();
-    await client.save();
+    // Track access analytics atomically to avoid lost updates under concurrency
+    await AccessClient.updateOne(
+      { _id: client._id },
+      {
+        $inc: { accessCount: 1 },
+        $set: { lastAccessAt: new Date() }
+      }
+    );
 
     return res.status(200).json({
       client: {

--- a/api/models/AccessClient.js
+++ b/api/models/AccessClient.js
@@ -3,35 +3,6 @@
 const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
 
-const accessPointSchema = new Schema(
-  {
-    code: {
-      type: String,
-      required: true,
-      trim: true,
-      uppercase: true
-    },
-    rootBoardId: {
-      type: Schema.Types.ObjectId,
-      ref: 'Board',
-      required: true
-    },
-    isListedInApp: {
-      type: Boolean,
-      default: true
-    },
-    accessCount: {
-      type: Number,
-      default: 0
-    },
-    lastAccessAt: {
-      type: Date,
-      default: null
-    }
-  },
-  { _id: true }
-);
-
 const ACCESS_CLIENT_SCHEMA_DEFINITION = {
   slug: {
     type: String,
@@ -71,8 +42,7 @@ const ACCESS_CLIENT_SCHEMA_DEFINITION = {
     type: Schema.Types.ObjectId,
     ref: 'User',
     required: true
-  },
-  accessPoints: [accessPointSchema]
+  }
 };
 
 const ACCESS_CLIENT_SCHEMA_OPTIONS = {

--- a/api/models/AccessClient.js
+++ b/api/models/AccessClient.js
@@ -1,0 +1,86 @@
+'use strict';
+
+const mongoose = require('mongoose');
+const Schema = mongoose.Schema;
+
+const ACCESS_CLIENT_SCHEMA_DEFINITION = {
+  code: {
+    type: String,
+    unique: true,
+    required: true,
+    trim: true,
+    uppercase: true
+  },
+  clientName: {
+    type: String,
+    required: true,
+    trim: true
+  },
+  clientContact: {
+    type: String,
+    trim: true
+  },
+  brandColor: {
+    type: String
+  },
+  rootBoardId: {
+    type: Schema.Types.ObjectId,
+    ref: 'Board',
+    required: true
+  },
+  isActive: {
+    type: Boolean,
+    default: true
+  },
+  isListedInApp: {
+    type: Boolean,
+    default: true
+  },
+  subscriptionStart: {
+    type: Date,
+    required: true
+  },
+  subscriptionEnd: {
+    type: Date,
+    required: true
+  },
+  accessCount: {
+    type: Number,
+    default: 0
+  },
+  lastAccessAt: {
+    type: Date
+  },
+  createdBy: {
+    type: Schema.Types.ObjectId,
+    ref: 'User',
+    required: true
+  }
+};
+
+const ACCESS_CLIENT_SCHEMA_OPTIONS = {
+  timestamps: true,
+  toObject: {
+    virtuals: true
+  },
+  toJSON: {
+    virtuals: true,
+    versionKey: false,
+    transform: function (doc, ret) {
+      ret.id = ret._id;
+      delete ret._id;
+    }
+  }
+};
+
+const accessClientSchema = new Schema(
+  ACCESS_CLIENT_SCHEMA_DEFINITION,
+  ACCESS_CLIENT_SCHEMA_OPTIONS
+);
+
+accessClientSchema.index({ code: 1 }, { unique: true });
+accessClientSchema.index({ isActive: 1, isListedInApp: 1 });
+
+const AccessClient = mongoose.model('AccessClient', accessClientSchema);
+
+module.exports = AccessClient;

--- a/api/models/AccessClient.js
+++ b/api/models/AccessClient.js
@@ -17,7 +17,11 @@ const ACCESS_CLIENT_SCHEMA_DEFINITION = {
       required: true,
       trim: true
     },
-    contact: {
+    email: {
+      type: String,
+      trim: true
+    },
+    phone: {
       type: String,
       trim: true
     }

--- a/api/models/AccessClient.js
+++ b/api/models/AccessClient.js
@@ -3,36 +3,59 @@
 const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
 
+const accessPointSchema = new Schema(
+  {
+    code: {
+      type: String,
+      required: true,
+      trim: true,
+      uppercase: true
+    },
+    rootBoardId: {
+      type: Schema.Types.ObjectId,
+      ref: 'Board',
+      required: true
+    },
+    isListedInApp: {
+      type: Boolean,
+      default: true
+    },
+    accessCount: {
+      type: Number,
+      default: 0
+    },
+    lastAccessAt: {
+      type: Date,
+      default: null
+    }
+  },
+  { _id: true }
+);
+
 const ACCESS_CLIENT_SCHEMA_DEFINITION = {
-  code: {
+  slug: {
     type: String,
     unique: true,
     required: true,
     trim: true,
-    uppercase: true
+    lowercase: true
   },
-  clientName: {
-    type: String,
-    required: true,
-    trim: true
-  },
-  clientContact: {
-    type: String,
-    trim: true
+  client: {
+    name: {
+      type: String,
+      required: true,
+      trim: true
+    },
+    contact: {
+      type: String,
+      trim: true
+    }
   },
   brandColor: {
-    type: String
-  },
-  rootBoardId: {
-    type: Schema.Types.ObjectId,
-    ref: 'Board',
-    required: true
+    type: String,
+    default: '#1976d2'
   },
   isActive: {
-    type: Boolean,
-    default: true
-  },
-  isListedInApp: {
     type: Boolean,
     default: true
   },
@@ -44,18 +67,12 @@ const ACCESS_CLIENT_SCHEMA_DEFINITION = {
     type: Date,
     required: true
   },
-  accessCount: {
-    type: Number,
-    default: 0
-  },
-  lastAccessAt: {
-    type: Date
-  },
   createdBy: {
     type: Schema.Types.ObjectId,
     ref: 'User',
     required: true
-  }
+  },
+  accessPoints: [accessPointSchema]
 };
 
 const ACCESS_CLIENT_SCHEMA_OPTIONS = {
@@ -66,7 +83,7 @@ const ACCESS_CLIENT_SCHEMA_OPTIONS = {
   toJSON: {
     virtuals: true,
     versionKey: false,
-    transform: function (doc, ret) {
+    transform: function(doc, ret) {
       ret.id = ret._id;
       delete ret._id;
     }
@@ -77,8 +94,6 @@ const accessClientSchema = new Schema(
   ACCESS_CLIENT_SCHEMA_DEFINITION,
   ACCESS_CLIENT_SCHEMA_OPTIONS
 );
-
-accessClientSchema.index({ isActive: 1, isListedInApp: 1 });
 
 const AccessClient = mongoose.model('AccessClient', accessClientSchema);
 

--- a/api/models/AccessClient.js
+++ b/api/models/AccessClient.js
@@ -78,7 +78,6 @@ const accessClientSchema = new Schema(
   ACCESS_CLIENT_SCHEMA_OPTIONS
 );
 
-accessClientSchema.index({ code: 1 }, { unique: true });
 accessClientSchema.index({ isActive: 1, isListedInApp: 1 });
 
 const AccessClient = mongoose.model('AccessClient', accessClientSchema);

--- a/api/models/AccessPoint.js
+++ b/api/models/AccessPoint.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const mongoose = require('mongoose');
+const Schema = mongoose.Schema;
+
+const ACCESS_POINT_SCHEMA_DEFINITION = {
+  code: {
+    type: String,
+    required: true,
+    trim: true,
+    uppercase: true,
+    unique: true,
+    index: true
+  },
+  accessClient: {
+    type: Schema.Types.ObjectId,
+    ref: 'AccessClient',
+    required: true
+  },
+  rootBoardId: {
+    type: Schema.Types.ObjectId,
+    ref: 'Board',
+    required: true
+  },
+  viewsCount: {
+    type: Number,
+    default: 0
+  },
+  lastAccessAt: {
+    type: Date,
+    default: null
+  }
+};
+
+const ACCESS_POINT_SCHEMA_OPTIONS = {
+  timestamps: true,
+  toObject: {
+    virtuals: true
+  },
+  toJSON: {
+    virtuals: true,
+    versionKey: false,
+    transform: function(doc, ret) {
+      ret.id = ret._id;
+      delete ret._id;
+    }
+  }
+};
+
+const accessPointSchema = new Schema(
+  ACCESS_POINT_SCHEMA_DEFINITION,
+  ACCESS_POINT_SCHEMA_OPTIONS
+);
+
+const AccessPoint = mongoose.model('AccessPoint', accessPointSchema);
+
+module.exports = AccessPoint;

--- a/api/models/AccessPoint.js
+++ b/api/models/AccessPoint.js
@@ -29,6 +29,11 @@ const ACCESS_POINT_SCHEMA_DEFINITION = {
   lastAccessAt: {
     type: Date,
     default: null
+  },
+  linkedBoardsIds: {
+    type: [Schema.Types.ObjectId],
+    ref: 'Board',
+    default: []
   }
 };
 

--- a/api/models/Board.js
+++ b/api/models/Board.js
@@ -67,7 +67,9 @@ const BOARD_SCHEMA_DEFINITION = {
     type: String,
     trim: true,
     uppercase: true,
-    default: null
+    default: null,
+    unique: true,
+    sparse: true
   }
 };
 
@@ -87,8 +89,8 @@ const BOARD_SCHEMA_OPTIONS = {
 
 const boardSchema = new Schema(BOARD_SCHEMA_DEFINITION, BOARD_SCHEMA_OPTIONS);
 
-// Sparse index skips documents where accessPointCode is null/missing, optimizing queries for Access boards
-boardSchema.index({ accessPointCode: 1 }, { sparse: true });
+// Sparse unique index skips documents where accessPointCode is null/missing, enforcing uniqueness only for set values
+boardSchema.index({ accessPointCode: 1 }, { sparse: true, unique: true });
 
 const validatePresenceOf = value => value && value.length;
 

--- a/api/models/Board.js
+++ b/api/models/Board.js
@@ -63,10 +63,11 @@ const BOARD_SCHEMA_DEFINITION = {
     default: false
   },
   grid: {},
-  accessCode: {
+  accessPointCode: {
     type: String,
     trim: true,
-    uppercase: true
+    uppercase: true,
+    default: null
   }
 };
 
@@ -86,8 +87,8 @@ const BOARD_SCHEMA_OPTIONS = {
 
 const boardSchema = new Schema(BOARD_SCHEMA_DEFINITION, BOARD_SCHEMA_OPTIONS);
 
-// Sparse index skips documents where accessCode is missing, optimizing queries for Access boards
-boardSchema.index({ accessCode: 1 }, { sparse: true });
+// Sparse index skips documents where accessPointCode is null/missing, optimizing queries for Access boards
+boardSchema.index({ accessPointCode: 1 }, { sparse: true });
 
 const validatePresenceOf = value => value && value.length;
 

--- a/api/models/Board.js
+++ b/api/models/Board.js
@@ -67,9 +67,7 @@ const BOARD_SCHEMA_DEFINITION = {
     type: String,
     trim: true,
     uppercase: true,
-    default: null,
-    unique: true,
-    sparse: true
+    default: null
   }
 };
 

--- a/test/controllers/access.js
+++ b/test/controllers/access.js
@@ -1,0 +1,425 @@
+//During the test the env variable is set to test
+process.env.NODE_ENV = 'test';
+
+//Require the dev-dependencies
+const chai = require('chai');
+var request = require('supertest');
+var expect = require('chai').expect;
+const should = chai.should();
+const helper = require('../helper');
+
+const AccessClient = require('../../api/models/AccessClient');
+const Board = require('../../api/models/Board');
+
+//Parent block
+describe('Access API calls', function () {
+  let adminUser;
+  let regularUser;
+  let server;
+  let testBoardId;
+  let testBoardId2;
+
+  before(async function () {
+    helper.prepareNodemailerMock(); //enable mockery and replace nodemailer with nodemailerMock
+    server = require('../../app'); //register mocks before require the original dependency
+  });
+
+  beforeEach(async function () {
+    // Create admin user
+    adminUser = await helper.prepareUser(server, {
+      role: 'admin',
+      email: helper.generateEmail(),
+    });
+
+    // Create regular user
+    regularUser = await helper.prepareUser(server, {
+      role: 'user',
+      email: helper.generateEmail(),
+    });
+
+    // Create test boards
+    testBoardId = await helper.createMochaBoard(server, adminUser.token);
+    testBoardId2 = await helper.createMochaBoard(server, adminUser.token);
+  });
+
+  after(async function () {
+    helper.prepareNodemailerMock(true); //disable mockery
+    await helper.deleteMochaUsers();
+    await Board.deleteMany({ author: 'cboard mocha test' });
+    await AccessClient.deleteMany({ clientName: /mocha test/i });
+  });
+
+  describe('POST /admin/access-clients', function () {
+    it('it should CREATE an access client with rootBoard only', async function () {
+      const clientData = {
+        code: 'TEST01',
+        clientName: 'Test Client mocha test',
+        clientContact: 'test@example.com',
+        brandColor: '#FF5733',
+        rootBoardId: testBoardId,
+        subscriptionStart: new Date(),
+        subscriptionEnd: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000), // 1 year from now
+      };
+
+      const res = await request(server)
+        .post('/admin/access-clients')
+        .send(clientData)
+        .set('Authorization', `Bearer ${adminUser.token}`)
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(201);
+
+      res.body.should.be.a('object');
+      res.body.should.have.property('code').eql('TEST01');
+      res.body.should.have.property('clientName').eql('Test Client mocha test');
+      res.body.should.have.property('brandColor').eql('#FF5733');
+      res.body.should.have.property('createdBy');
+
+      // Verify board was updated with accessCode
+      const board = await Board.findById(testBoardId);
+      board.accessCode.should.eql('TEST01');
+    });
+
+    it('it should CREATE an access client with multiple boards', async function () {
+      const clientData = {
+        code: 'TEST02',
+        clientName: 'Test Client 2 mocha test',
+        rootBoardId: testBoardId,
+        subscriptionStart: new Date(),
+        subscriptionEnd: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000),
+        boardIds: [testBoardId, testBoardId2],
+      };
+
+      const res = await request(server)
+        .post('/admin/access-clients')
+        .send(clientData)
+        .set('Authorization', `Bearer ${adminUser.token}`)
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(201);
+
+      res.body.should.have.property('code').eql('TEST02');
+
+      // Verify both boards were updated
+      const board1 = await Board.findById(testBoardId);
+      const board2 = await Board.findById(testBoardId2);
+      board1.accessCode.should.eql('TEST02');
+      board2.accessCode.should.eql('TEST02');
+    });
+
+    it('it should include rootBoard even when boardIds is empty array', async function () {
+      const clientData = {
+        code: 'TEST03',
+        clientName: 'Test Client 3 mocha test',
+        rootBoardId: testBoardId,
+        subscriptionStart: new Date(),
+        subscriptionEnd: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000),
+        boardIds: [], // Empty array
+      };
+
+      const res = await request(server)
+        .post('/admin/access-clients')
+        .send(clientData)
+        .set('Authorization', `Bearer ${adminUser.token}`)
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(201);
+
+      // Verify rootBoard was updated despite empty boardIds
+      const board = await Board.findById(testBoardId);
+      board.accessCode.should.eql('TEST03');
+    });
+
+    it('it should NOT CREATE with duplicate code', async function () {
+      const clientData = {
+        code: 'DUPLICATE',
+        clientName: 'Test Client mocha test',
+        rootBoardId: testBoardId,
+        subscriptionStart: new Date(),
+        subscriptionEnd: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000),
+      };
+
+      // Create first client
+      await request(server)
+        .post('/admin/access-clients')
+        .send(clientData)
+        .set('Authorization', `Bearer ${adminUser.token}`)
+        .expect(201);
+
+      // Try to create duplicate
+      const res = await request(server)
+        .post('/admin/access-clients')
+        .send(clientData)
+        .set('Authorization', `Bearer ${adminUser.token}`)
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(409);
+
+      res.body.should.have.property('message').eql('Code already exists');
+    });
+
+    it('it should NOT CREATE with non-existent rootBoardId', async function () {
+      const clientData = {
+        code: 'TEST04',
+        clientName: 'Test Client mocha test',
+        rootBoardId: '507f1f77bcf86cd799439011', // Non-existent ID
+        subscriptionStart: new Date(),
+        subscriptionEnd: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000),
+      };
+
+      const res = await request(server)
+        .post('/admin/access-clients')
+        .send(clientData)
+        .set('Authorization', `Bearer ${adminUser.token}`)
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(404);
+
+      res.body.should.have.property('message').eql('Root board not found');
+    });
+
+    it('it should NOT CREATE without authorization', async function () {
+      const clientData = {
+        code: 'TEST05',
+        clientName: 'Test Client mocha test',
+        rootBoardId: testBoardId,
+        subscriptionStart: new Date(),
+        subscriptionEnd: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000),
+      };
+
+      await request(server)
+        .post('/admin/access-clients')
+        .send(clientData)
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(403);
+    });
+  });
+
+  describe('GET /admin/access-clients', function () {
+    beforeEach(async function () {
+      // Create test clients
+      await request(server)
+        .post('/admin/access-clients')
+        .send({
+          code: 'LIST01',
+          clientName: 'List Test 1 mocha test',
+          rootBoardId: testBoardId,
+          subscriptionStart: new Date(),
+          subscriptionEnd: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000), // 30 days
+          boardIds: [testBoardId, testBoardId2],
+        })
+        .set('Authorization', `Bearer ${adminUser.token}`);
+
+      await request(server)
+        .post('/admin/access-clients')
+        .send({
+          code: 'LIST02',
+          clientName: 'List Test 2 mocha test',
+          rootBoardId: testBoardId,
+          subscriptionStart: new Date(Date.now() - 60 * 24 * 60 * 60 * 1000),
+          subscriptionEnd: new Date(Date.now() - 10 * 24 * 60 * 60 * 1000), // Expired
+        })
+        .set('Authorization', `Bearer ${adminUser.token}`);
+    });
+
+    it('it should LIST all access clients with stats', async function () {
+      const res = await request(server)
+        .get('/admin/access-clients')
+        .set('Authorization', `Bearer ${adminUser.token}`)
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200);
+
+      res.body.should.be.a('object');
+      res.body.should.have.property('total');
+      res.body.should.have.property('data').that.is.an('array');
+      res.body.data.length.should.be.at.least(2);
+
+      // Check first client
+      const client1 = res.body.data.find((c) => c.code === 'LIST01');
+      client1.should.have.property('boardCount').eql(2);
+      client1.should.have.property('isExpired').eql(false);
+      client1.should.have.property('daysUntilExpiry');
+      client1.daysUntilExpiry.should.be.at.least(0);
+
+      // Check expired client
+      const client2 = res.body.data.find((c) => c.code === 'LIST02');
+      client2.should.have.property('isExpired').eql(true);
+      client2.should.have.property('daysUntilExpiry').eql(0); // Should be clamped at 0
+    });
+
+    it('it should NOT LIST without authorization', async function () {
+      await request(server)
+        .get('/admin/access-clients')
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(403);
+    });
+  });
+
+  describe('PUT /admin/access-clients/:code', function () {
+    beforeEach(async function () {
+      await request(server)
+        .post('/admin/access-clients')
+        .send({
+          code: 'UPDATE01',
+          clientName: 'Update Test mocha test',
+          rootBoardId: testBoardId,
+          subscriptionStart: new Date(),
+          subscriptionEnd: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000),
+          brandColor: '#000000',
+        })
+        .set('Authorization', `Bearer ${adminUser.token}`);
+    });
+
+    it('it should UPDATE an access client', async function () {
+      const updates = {
+        clientName: 'Updated Name mocha test',
+        brandColor: '#FFFFFF',
+        isActive: false,
+      };
+
+      const res = await request(server)
+        .put('/admin/access-clients/UPDATE01')
+        .send(updates)
+        .set('Authorization', `Bearer ${adminUser.token}`)
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200);
+
+      res.body.should.have.property('clientName').eql('Updated Name mocha test');
+      res.body.should.have.property('brandColor').eql('#FFFFFF');
+      res.body.should.have.property('isActive').eql(false);
+    });
+
+    it('it should UPDATE subscription dates', async function () {
+      const newEndDate = new Date(Date.now() + 730 * 24 * 60 * 60 * 1000); // 2 years
+      const updates = {
+        subscriptionEnd: newEndDate,
+      };
+
+      const res = await request(server)
+        .put('/admin/access-clients/UPDATE01')
+        .send(updates)
+        .set('Authorization', `Bearer ${adminUser.token}`)
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200);
+
+      const actualDate = new Date(res.body.subscriptionEnd);
+      actualDate.getTime().should.be.closeTo(newEndDate.getTime(), 1000);
+    });
+
+    it('it should return 404 for non-existent code', async function () {
+      const res = await request(server)
+        .put('/admin/access-clients/NONEXISTENT')
+        .send({ clientName: 'Test' })
+        .set('Authorization', `Bearer ${adminUser.token}`)
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(404);
+
+      res.body.should.have.property('message').eql('Client not found');
+    });
+
+    it('it should NOT UPDATE without authorization', async function () {
+      await request(server)
+        .put('/admin/access-clients/UPDATE01')
+        .send({ clientName: 'Test' })
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(403);
+    });
+  });
+
+  describe('GET /admin/access-clients/:code/stats', function () {
+    beforeEach(async function () {
+      await request(server)
+        .post('/admin/access-clients')
+        .send({
+          code: 'STATS01',
+          clientName: 'Stats Test mocha test',
+          rootBoardId: testBoardId,
+          subscriptionStart: new Date(),
+          subscriptionEnd: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000),
+          boardIds: [testBoardId, testBoardId2],
+        })
+        .set('Authorization', `Bearer ${adminUser.token}`);
+    });
+
+    it('it should GET client statistics', async function () {
+      const res = await request(server)
+        .get('/admin/access-clients/STATS01/stats')
+        .set('Authorization', `Bearer ${adminUser.token}`)
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200);
+
+      res.body.should.be.a('object');
+      res.body.should.have.property('client');
+      res.body.should.have.property('stats');
+
+      // Verify client data
+      res.body.client.should.have.property('code').eql('STATS01');
+      res.body.client.should.have.property('clientName').eql('Stats Test mocha test');
+
+      // Verify stats
+      res.body.stats.should.have.property('totalAccesses').eql(0);
+      res.body.stats.should.have.property('boardCount').eql(2);
+      res.body.stats.should.have.property('boards').that.is.an('array');
+      res.body.stats.boards.length.should.eql(2);
+      res.body.stats.should.have.property('daysUntilExpiry');
+      res.body.stats.daysUntilExpiry.should.be.at.least(0);
+      res.body.stats.should.have.property('isExpired').eql(false);
+
+      // Verify board details
+      res.body.stats.boards[0].should.have.property('id');
+      res.body.stats.boards[0].should.have.property('name');
+      res.body.stats.boards[0].should.have.property('tilesCount');
+    });
+
+    it('it should return 0 daysUntilExpiry for expired client', async function () {
+      // Create expired client
+      await request(server)
+        .post('/admin/access-clients')
+        .send({
+          code: 'EXPIRED01',
+          clientName: 'Expired Test mocha test',
+          rootBoardId: testBoardId,
+          subscriptionStart: new Date(Date.now() - 60 * 24 * 60 * 60 * 1000),
+          subscriptionEnd: new Date(Date.now() - 10 * 24 * 60 * 60 * 1000),
+        })
+        .set('Authorization', `Bearer ${adminUser.token}`);
+
+      const res = await request(server)
+        .get('/admin/access-clients/EXPIRED01/stats')
+        .set('Authorization', `Bearer ${adminUser.token}`)
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200);
+
+      res.body.stats.should.have.property('isExpired').eql(true);
+      res.body.stats.should.have.property('daysUntilExpiry').eql(0); // Clamped at 0
+    });
+
+    it('it should return 404 for non-existent code', async function () {
+      const res = await request(server)
+        .get('/admin/access-clients/NONEXISTENT/stats')
+        .set('Authorization', `Bearer ${adminUser.token}`)
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(404);
+
+      res.body.should.have.property('message').eql('Client not found');
+    });
+
+    it('it should NOT GET stats without authorization', async function () {
+      await request(server)
+        .get('/admin/access-clients/STATS01/stats')
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(403);
+    });
+  });
+});

--- a/test/controllers/access.js
+++ b/test/controllers/access.js
@@ -9,6 +9,7 @@ const should = chai.should();
 const helper = require('../helper');
 
 const AccessClient = require('../../api/models/AccessClient');
+const AccessPoint = require('../../api/models/AccessPoint');
 const Board = require('../../api/models/Board');
 
 //Parent block
@@ -46,19 +47,23 @@ describe('Access API calls', function () {
     helper.prepareNodemailerMock(true); //disable mockery
     await helper.deleteMochaUsers();
     await Board.deleteMany({ author: 'cboard mocha test' });
-    await AccessClient.deleteMany({ clientName: /mocha test/i });
+    const clients = await AccessClient.find({ 'client.name': /mocha test/i });
+    const clientIds = clients.map(c => c._id);
+    await AccessPoint.deleteMany({ accessClient: { $in: clientIds } });
+    await AccessClient.deleteMany({ 'client.name': /mocha test/i });
   });
 
   describe('POST /admin/access-clients', function () {
-    it('it should CREATE an access client with rootBoard only', async function () {
+    it('it should CREATE an access client and auto-discover linked boards', async function () {
       const clientData = {
-        code: 'TEST01',
+        slug: 'test-01',
         clientName: 'Test Client mocha test',
         clientContact: 'test@example.com',
         brandColor: '#FF5733',
         rootBoardId: testBoardId,
+        accessPointCode: 'TEST01',
         subscriptionStart: new Date(),
-        subscriptionEnd: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000), // 1 year from now
+        subscriptionEnd: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000),
       };
 
       const res = await request(server)
@@ -70,71 +75,26 @@ describe('Access API calls', function () {
         .expect(201);
 
       res.body.should.be.a('object');
-      res.body.should.have.property('code').eql('TEST01');
-      res.body.should.have.property('clientName').eql('Test Client mocha test');
+      res.body.should.have.property('slug').eql('test-01');
+      res.body.client.should.have.property('name').eql('Test Client mocha test');
       res.body.should.have.property('brandColor').eql('#FF5733');
       res.body.should.have.property('createdBy');
+      res.body.should.have.property('accessPoint');
+      res.body.accessPoint.should.have.property('code').eql('TEST01');
+      // rootBoard has no tile links, so discovery returns just the root
+      res.body.accessPoint.linkedBoardsIds.length.should.eql(1);
 
-      // Verify board was updated with accessCode
+      // Verify board was marked with accessPointCode
       const board = await Board.findById(testBoardId);
-      board.accessCode.should.eql('TEST01');
+      board.accessPointCode.should.eql('TEST01');
     });
 
-    it('it should CREATE an access client with multiple boards', async function () {
+    it('it should NOT CREATE with duplicate slug', async function () {
       const clientData = {
-        code: 'TEST02',
-        clientName: 'Test Client 2 mocha test',
-        rootBoardId: testBoardId,
-        subscriptionStart: new Date(),
-        subscriptionEnd: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000),
-        boardIds: [testBoardId, testBoardId2],
-      };
-
-      const res = await request(server)
-        .post('/admin/access-clients')
-        .send(clientData)
-        .set('Authorization', `Bearer ${adminUser.token}`)
-        .set('Accept', 'application/json')
-        .expect('Content-Type', /json/)
-        .expect(201);
-
-      res.body.should.have.property('code').eql('TEST02');
-
-      // Verify both boards were updated
-      const board1 = await Board.findById(testBoardId);
-      const board2 = await Board.findById(testBoardId2);
-      board1.accessCode.should.eql('TEST02');
-      board2.accessCode.should.eql('TEST02');
-    });
-
-    it('it should include rootBoard even when boardIds is empty array', async function () {
-      const clientData = {
-        code: 'TEST03',
-        clientName: 'Test Client 3 mocha test',
-        rootBoardId: testBoardId,
-        subscriptionStart: new Date(),
-        subscriptionEnd: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000),
-        boardIds: [], // Empty array
-      };
-
-      const res = await request(server)
-        .post('/admin/access-clients')
-        .send(clientData)
-        .set('Authorization', `Bearer ${adminUser.token}`)
-        .set('Accept', 'application/json')
-        .expect('Content-Type', /json/)
-        .expect(201);
-
-      // Verify rootBoard was updated despite empty boardIds
-      const board = await Board.findById(testBoardId);
-      board.accessCode.should.eql('TEST03');
-    });
-
-    it('it should NOT CREATE with duplicate code', async function () {
-      const clientData = {
-        code: 'DUPLICATE',
+        slug: 'duplicate',
         clientName: 'Test Client mocha test',
         rootBoardId: testBoardId,
+        accessPointCode: 'DUPL01',
         subscriptionStart: new Date(),
         subscriptionEnd: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000),
       };
@@ -146,10 +106,39 @@ describe('Access API calls', function () {
         .set('Authorization', `Bearer ${adminUser.token}`)
         .expect(201);
 
-      // Try to create duplicate
+      // Try to create with same slug
       const res = await request(server)
         .post('/admin/access-clients')
+        .send({ ...clientData, accessPointCode: 'DUPL02' })
+        .set('Authorization', `Bearer ${adminUser.token}`)
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(409);
+
+      res.body.should.have.property('message').eql('Slug already exists');
+    });
+
+    it('it should NOT CREATE with duplicate access point code', async function () {
+      const clientData = {
+        slug: 'duplicate-code-a',
+        clientName: 'Test Client mocha test',
+        rootBoardId: testBoardId,
+        accessPointCode: 'DUPCODE',
+        subscriptionStart: new Date(),
+        subscriptionEnd: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000),
+      };
+
+      // Create first client
+      await request(server)
+        .post('/admin/access-clients')
         .send(clientData)
+        .set('Authorization', `Bearer ${adminUser.token}`)
+        .expect(201);
+
+      // Try to create with same accessPointCode but different slug
+      const res = await request(server)
+        .post('/admin/access-clients')
+        .send({ ...clientData, slug: 'duplicate-code-b' })
         .set('Authorization', `Bearer ${adminUser.token}`)
         .set('Accept', 'application/json')
         .expect('Content-Type', /json/)
@@ -160,9 +149,10 @@ describe('Access API calls', function () {
 
     it('it should NOT CREATE with non-existent rootBoardId', async function () {
       const clientData = {
-        code: 'TEST04',
+        slug: 'test-04',
         clientName: 'Test Client mocha test',
         rootBoardId: '507f1f77bcf86cd799439011', // Non-existent ID
+        accessPointCode: 'TEST04',
         subscriptionStart: new Date(),
         subscriptionEnd: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000),
       };
@@ -180,9 +170,10 @@ describe('Access API calls', function () {
 
     it('it should NOT CREATE without authorization', async function () {
       const clientData = {
-        code: 'TEST05',
+        slug: 'test-05',
         clientName: 'Test Client mocha test',
         rootBoardId: testBoardId,
+        accessPointCode: 'TEST05',
         subscriptionStart: new Date(),
         subscriptionEnd: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000),
       };
@@ -202,21 +193,22 @@ describe('Access API calls', function () {
       await request(server)
         .post('/admin/access-clients')
         .send({
-          code: 'LIST01',
+          slug: 'list-01',
           clientName: 'List Test 1 mocha test',
           rootBoardId: testBoardId,
+          accessPointCode: 'LIST01',
           subscriptionStart: new Date(),
           subscriptionEnd: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000), // 30 days
-          boardIds: [testBoardId, testBoardId2],
         })
         .set('Authorization', `Bearer ${adminUser.token}`);
 
       await request(server)
         .post('/admin/access-clients')
         .send({
-          code: 'LIST02',
+          slug: 'list-02',
           clientName: 'List Test 2 mocha test',
           rootBoardId: testBoardId,
+          accessPointCode: 'LIST02',
           subscriptionStart: new Date(Date.now() - 60 * 24 * 60 * 60 * 1000),
           subscriptionEnd: new Date(Date.now() - 10 * 24 * 60 * 60 * 1000), // Expired
         })
@@ -236,15 +228,15 @@ describe('Access API calls', function () {
       res.body.should.have.property('data').that.is.an('array');
       res.body.data.length.should.be.at.least(2);
 
-      // Check first client
-      const client1 = res.body.data.find((c) => c.code === 'LIST01');
-      client1.should.have.property('boardCount').eql(2);
+      // Test boards have no tile links, so auto-discovery returns just root = 1 board
+      const client1 = res.body.data.find((c) => c.slug === 'list-01');
+      client1.should.have.property('boardCount').eql(1);
       client1.should.have.property('isExpired').eql(false);
       client1.should.have.property('daysUntilExpiry');
       client1.daysUntilExpiry.should.be.at.least(0);
 
       // Check expired client
-      const client2 = res.body.data.find((c) => c.code === 'LIST02');
+      const client2 = res.body.data.find((c) => c.slug === 'list-02');
       client2.should.have.property('isExpired').eql(true);
       client2.should.have.property('daysUntilExpiry').eql(0); // Should be clamped at 0
     });
@@ -258,14 +250,15 @@ describe('Access API calls', function () {
     });
   });
 
-  describe('PUT /admin/access-clients/:code', function () {
+  describe('PUT /admin/access-clients/:slug', function () {
     beforeEach(async function () {
       await request(server)
         .post('/admin/access-clients')
         .send({
-          code: 'UPDATE01',
+          slug: 'update-01',
           clientName: 'Update Test mocha test',
           rootBoardId: testBoardId,
+          accessPointCode: 'UPDATE01',
           subscriptionStart: new Date(),
           subscriptionEnd: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000),
           brandColor: '#000000',
@@ -281,14 +274,14 @@ describe('Access API calls', function () {
       };
 
       const res = await request(server)
-        .put('/admin/access-clients/UPDATE01')
+        .put('/admin/access-clients/update-01')
         .send(updates)
         .set('Authorization', `Bearer ${adminUser.token}`)
         .set('Accept', 'application/json')
         .expect('Content-Type', /json/)
         .expect(200);
 
-      res.body.should.have.property('clientName').eql('Updated Name mocha test');
+      res.body.client.should.have.property('name').eql('Updated Name mocha test');
       res.body.should.have.property('brandColor').eql('#FFFFFF');
       res.body.should.have.property('isActive').eql(false);
     });
@@ -300,7 +293,7 @@ describe('Access API calls', function () {
       };
 
       const res = await request(server)
-        .put('/admin/access-clients/UPDATE01')
+        .put('/admin/access-clients/update-01')
         .send(updates)
         .set('Authorization', `Bearer ${adminUser.token}`)
         .set('Accept', 'application/json')
@@ -311,9 +304,9 @@ describe('Access API calls', function () {
       actualDate.getTime().should.be.closeTo(newEndDate.getTime(), 1000);
     });
 
-    it('it should return 404 for non-existent code', async function () {
+    it('it should return 404 for non-existent slug', async function () {
       const res = await request(server)
-        .put('/admin/access-clients/NONEXISTENT')
+        .put('/admin/access-clients/nonexistent')
         .send({ clientName: 'Test' })
         .set('Authorization', `Bearer ${adminUser.token}`)
         .set('Accept', 'application/json')
@@ -325,7 +318,7 @@ describe('Access API calls', function () {
 
     it('it should NOT UPDATE without authorization', async function () {
       await request(server)
-        .put('/admin/access-clients/UPDATE01')
+        .put('/admin/access-clients/update-01')
         .send({ clientName: 'Test' })
         .set('Accept', 'application/json')
         .expect('Content-Type', /json/)
@@ -333,24 +326,92 @@ describe('Access API calls', function () {
     });
   });
 
-  describe('GET /admin/access-clients/:code/stats', function () {
+  describe('PUT /admin/access-points/:code', function () {
     beforeEach(async function () {
       await request(server)
         .post('/admin/access-clients')
         .send({
-          code: 'STATS01',
-          clientName: 'Stats Test mocha test',
+          slug: 'ap-update-01',
+          clientName: 'Access Point Update Test mocha test',
           rootBoardId: testBoardId,
+          accessPointCode: 'APUPDATE01',
           subscriptionStart: new Date(),
           subscriptionEnd: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000),
-          boardIds: [testBoardId, testBoardId2],
+        })
+        .set('Authorization', `Bearer ${adminUser.token}`);
+    });
+
+    it('it should re-discover boards when updating access point root', async function () {
+      const res = await request(server)
+        .put('/admin/access-points/APUPDATE01')
+        .send({ rootBoardId: testBoardId2 })
+        .set('Authorization', `Bearer ${adminUser.token}`)
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200);
+
+      res.body.should.have.property('code').eql('APUPDATE01');
+      res.body.should.have.property('linkedBoardsIds').that.is.an('array');
+      res.body.linkedBoardsIds.should.include(testBoardId2.toString());
+
+      // Verify new root board was marked with accessPointCode
+      const board = await Board.findById(testBoardId2);
+      board.accessPointCode.should.eql('APUPDATE01');
+    });
+
+    it('it should re-discover without changing root when no rootBoardId provided', async function () {
+      const res = await request(server)
+        .put('/admin/access-points/APUPDATE01')
+        .send({})
+        .set('Authorization', `Bearer ${adminUser.token}`)
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200);
+
+      res.body.should.have.property('code').eql('APUPDATE01');
+      res.body.linkedBoardsIds.should.include(testBoardId.toString());
+    });
+
+    it('it should return 404 for non-existent access point code', async function () {
+      const res = await request(server)
+        .put('/admin/access-points/NONEXISTENT')
+        .send({})
+        .set('Authorization', `Bearer ${adminUser.token}`)
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(404);
+
+      res.body.should.have.property('message').eql('Access point not found');
+    });
+
+    it('it should NOT UPDATE without authorization', async function () {
+      await request(server)
+        .put('/admin/access-points/APUPDATE01')
+        .send({})
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(403);
+    });
+  });
+
+  describe('GET /admin/access-clients/:slug/stats', function () {
+    beforeEach(async function () {
+      await request(server)
+        .post('/admin/access-clients')
+        .send({
+          slug: 'stats-01',
+          clientName: 'Stats Test mocha test',
+          rootBoardId: testBoardId,
+          accessPointCode: 'STATS01',
+          subscriptionStart: new Date(),
+          subscriptionEnd: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000),
         })
         .set('Authorization', `Bearer ${adminUser.token}`);
     });
 
     it('it should GET client statistics', async function () {
       const res = await request(server)
-        .get('/admin/access-clients/STATS01/stats')
+        .get('/admin/access-clients/stats-01/stats')
         .set('Authorization', `Bearer ${adminUser.token}`)
         .set('Accept', 'application/json')
         .expect('Content-Type', /json/)
@@ -361,14 +422,14 @@ describe('Access API calls', function () {
       res.body.should.have.property('stats');
 
       // Verify client data
-      res.body.client.should.have.property('code').eql('STATS01');
-      res.body.client.should.have.property('clientName').eql('Stats Test mocha test');
+      res.body.client.should.have.property('slug').eql('stats-01');
+      res.body.client.client.should.have.property('name').eql('Stats Test mocha test');
 
-      // Verify stats
+      // Verify stats — test board has no tile links, so auto-discovery returns 1 board
       res.body.stats.should.have.property('totalAccesses').eql(0);
-      res.body.stats.should.have.property('boardCount').eql(2);
+      res.body.stats.should.have.property('boardCount').eql(1);
       res.body.stats.should.have.property('boards').that.is.an('array');
-      res.body.stats.boards.length.should.eql(2);
+      res.body.stats.boards.length.should.eql(1);
       res.body.stats.should.have.property('daysUntilExpiry');
       res.body.stats.daysUntilExpiry.should.be.at.least(0);
       res.body.stats.should.have.property('isExpired').eql(false);
@@ -384,16 +445,17 @@ describe('Access API calls', function () {
       await request(server)
         .post('/admin/access-clients')
         .send({
-          code: 'EXPIRED01',
+          slug: 'expired-01',
           clientName: 'Expired Test mocha test',
           rootBoardId: testBoardId,
+          accessPointCode: 'EXPIRED01',
           subscriptionStart: new Date(Date.now() - 60 * 24 * 60 * 60 * 1000),
           subscriptionEnd: new Date(Date.now() - 10 * 24 * 60 * 60 * 1000),
         })
         .set('Authorization', `Bearer ${adminUser.token}`);
 
       const res = await request(server)
-        .get('/admin/access-clients/EXPIRED01/stats')
+        .get('/admin/access-clients/expired-01/stats')
         .set('Authorization', `Bearer ${adminUser.token}`)
         .set('Accept', 'application/json')
         .expect('Content-Type', /json/)
@@ -403,9 +465,9 @@ describe('Access API calls', function () {
       res.body.stats.should.have.property('daysUntilExpiry').eql(0); // Clamped at 0
     });
 
-    it('it should return 404 for non-existent code', async function () {
+    it('it should return 404 for non-existent slug', async function () {
       const res = await request(server)
-        .get('/admin/access-clients/NONEXISTENT/stats')
+        .get('/admin/access-clients/nonexistent/stats')
         .set('Authorization', `Bearer ${adminUser.token}`)
         .set('Accept', 'application/json')
         .expect('Content-Type', /json/)
@@ -416,7 +478,7 @@ describe('Access API calls', function () {
 
     it('it should NOT GET stats without authorization', async function () {
       await request(server)
-        .get('/admin/access-clients/STATS01/stats')
+        .get('/admin/access-clients/stats-01/stats')
         .set('Accept', 'application/json')
         .expect('Content-Type', /json/)
         .expect(403);

--- a/test/controllers/board.js
+++ b/test/controllers/board.js
@@ -252,11 +252,11 @@ describe('Board API calls', function () {
     });
   });
 
-  describe('accessCode field behavior', function () {
-    it('should normalize accessCode to uppercase when creating a board', async function () {
+  describe('accessPointCode field behavior', function () {
+    it('should normalize accessPointCode to uppercase when creating a board', async function () {
       const boardWithAccessCode = {
         ...helper.boardData,
-        accessCode: 'cafe01'
+        accessPointCode: 'cafe01'
       };
       const res = await request(server)
         .post('/board')
@@ -266,14 +266,14 @@ describe('Board API calls', function () {
         .expect('Content-Type', /json/)
         .expect(200);
 
-      res.body.should.have.property('accessCode');
-      res.body.accessCode.should.equal('CAFE01');
+      res.body.should.have.property('accessPointCode');
+      res.body.accessPointCode.should.equal('CAFE01');
     });
 
-    it('should trim whitespace from accessCode', async function () {
+    it('should trim whitespace from accessPointCode', async function () {
       const boardWithAccessCode = {
         ...helper.boardData,
-        accessCode: '  test01  '
+        accessPointCode: '  test01  '
       };
       const res = await request(server)
         .post('/board')
@@ -283,13 +283,13 @@ describe('Board API calls', function () {
         .expect('Content-Type', /json/)
         .expect(200);
 
-      res.body.should.have.property('accessCode');
-      res.body.accessCode.should.equal('TEST01');
+      res.body.should.have.property('accessPointCode');
+      res.body.accessPointCode.should.equal('TEST01');
     });
 
-    it('should not include accessCode when not provided', async function () {
+    it('should default accessPointCode to null when not provided', async function () {
       const boardWithoutAccessCode = { ...helper.boardData };
-      delete boardWithoutAccessCode.accessCode;
+      delete boardWithoutAccessCode.accessPointCode;
 
       const res = await request(server)
         .post('/board')
@@ -299,15 +299,15 @@ describe('Board API calls', function () {
         .expect('Content-Type', /json/)
         .expect(200);
 
-      res.body.should.not.have.property('accessCode');
+      res.body.accessPointCode.should.equal(null);
     });
 
-    it('should update accessCode on an existing board', async function () {
+    it('should update accessPointCode on an existing board', async function () {
       const boardId = await helper.createMochaBoard(server, user.token);
 
       const updateData = {
         ...helper.boardData,
-        accessCode: 'updated01'
+        accessPointCode: 'updated01'
       };
       const res = await request(server)
         .put('/board/' + boardId)
@@ -317,14 +317,14 @@ describe('Board API calls', function () {
         .expect('Content-Type', /json/)
         .expect(200);
 
-      res.body.should.have.property('accessCode');
-      res.body.accessCode.should.equal('UPDATED01');
+      res.body.should.have.property('accessPointCode');
+      res.body.accessPointCode.should.equal('UPDATED01');
     });
 
-    it('should return accessCode in GET response when set', async function () {
+    it('should return accessPointCode in GET response when set', async function () {
       const boardWithAccessCode = {
         ...helper.boardData,
-        accessCode: 'gettest01'
+        accessPointCode: 'gettest01'
       };
       const createRes = await request(server)
         .post('/board')
@@ -343,8 +343,8 @@ describe('Board API calls', function () {
         .expect('Content-Type', /json/)
         .expect(200);
 
-      getRes.body.should.have.property('accessCode');
-      getRes.body.accessCode.should.equal('GETTEST01');
+      getRes.body.should.have.property('accessPointCode');
+      getRes.body.accessPointCode.should.equal('GETTEST01');
     });
   });
 


### PR DESCRIPTION
Implements 4 admin-protected controller functions in `access.js` for managing Cboard Access clients via Postman (or future admin panel). These endpoints enable creating, listing, updating, and viewing statistics for Access clients.

**File: `api/controllers/access.js`**

### Changes Made
Added 4 new admin controller functions:

1. **`createAccessClient`** (POST `/admin/access-clients`)
   - Creates a new Access client with validation
   - Verifies root board exists before creation
   - Associates boards by updating their `accessCode` field
   - Returns 409 if code already exists (duplicate protection)
   - Uses `req.user.id` for `createdBy` field

2. **`listAccessClients`** (GET `/admin/access-clients`)
   - Lists all Access clients with computed statistics
   - Populates `rootBoardId` (name) and `createdBy` (name, email)
   - Returns `boardCount`, `isExpired`, and `daysUntilExpiry` for each client
   - Sorted by creation date (newest first)

3. **`updateAccessClient`** (PUT `/admin/access-clients/:code`)
   - Updates existing client fields
   - Allows updating: `isActive`, `isListedInApp`, subscription dates, branding
   - Returns 404 if client not found

4. **`getAccessClientStats`** (GET `/admin/access-clients/:code/stats`)
   - Returns detailed client statistics
   - Includes access analytics (`totalAccesses`, `lastAccessAt`)
   - Lists all associated boards with tile counts
   - Provides expiry status and days until expiration

Closes #443

