### PR TITLE
Revert user data population changes

### DIFF
--- a/api/controllers/user.js
+++ b/api/controllers/user.js
@@ -150,7 +150,8 @@ async function passportLogin(ip, type, accessToken, refreshToken, profile, done)
   try {
     const propertyId = USER_MODEL_ID_TYPE[type];
     let user = await User.findOne({ [propertyId]: profile.id })
-      .populate('communicators')  
+      .populate('communicators')
+      .populate('boards')
       .exec();
 
 
@@ -316,7 +317,7 @@ async function listUser(req, res) {
     User,
     {
       query,
-      populate: ['communicators']
+      populate: ['communicators', 'boards']
     },
     req.query
   );
@@ -342,6 +343,7 @@ async function getUser(req, res) {
   try {
     const user = await User.findById(id)
       .populate('communicators')
+      .populate('boards')
       .exec();
 
     if (!user) {
@@ -385,6 +387,7 @@ function updateUser(req, res) {
 
   User.findById(id)
     .populate('communicators')
+    .populate('boards')
     .exec(async function (err, user) {
       if (err) {
         return res.status(500).json({

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -127,6 +127,12 @@ userSchema.virtual('communicators', {
   foreignField: 'email'
 });
 
+userSchema.virtual('boards', {
+  ref: 'Board',
+  localField: 'email',
+  foreignField: 'email'
+});
+
 userSchema.virtual('isAdmin').get(function() {
   return this.role === 'admin';
 });
@@ -198,6 +204,7 @@ userSchema.pre('save', function(next) {
 userSchema.post('save', function(doc, next) {
   doc
     .populate('communicators')
+    .populate('boards')
     .execPopulate()
     .then(function() {
       next();
@@ -236,6 +243,7 @@ userSchema.statics = {
     return this.findOne(options.criteria)
       .select(options.select)
       .populate('communicators')
+      .populate('boards')
       .exec(cb);
   },
 
@@ -250,6 +258,7 @@ userSchema.statics = {
   authenticate: function(email, password, callback) {
     this.findOne({ email: email })
       .populate('communicators')
+      .populate('boards')
       .exec(function(err, user) {
         if (err) {
           return callback(err);
@@ -285,6 +294,7 @@ userSchema.statics = {
     try {
       user = await this.findById(id)
         .populate('communicators')
+        .populate('boards')
         .exec();
     } catch (e) {}
 

--- a/test/controllers/user.js
+++ b/test/controllers/user.js
@@ -103,12 +103,6 @@ describe('User API calls', function () {
         it('it should contain a field indicating the user created date', function() {
           res.body.should.to.have.property('createdAt');
         })
-        it('it should not contain a field with the boards of the user', function() {
-          res.body.should.not.have.property('boards');
-        })
-        it('it should contain a field with the communicators of the user', function() {
-          res.body.should.have.property('communicators');
-        })
       });
     });
   });
@@ -154,8 +148,6 @@ describe('User API calls', function () {
 
       const getUser = res.body;
       getUser.should.to.have.any.keys('name', 'role', 'provider', 'email');
-      res.body.should.not.have.property('boards');
-      res.body.should.have.property('communicators');
     });
   });
 


### PR DESCRIPTION
Revert changes that removed the population of 'boards' in user data queries and tests. This restores the previous behavior of including 'boards' alongside 'communicators'.