### PR TITLE
Change Access endpoint to /access/:slug/:code

### DIFF
--- a/api/controllers/access.js
+++ b/api/controllers/access.js
@@ -103,15 +103,16 @@ async function getClients(req, res) {
 }
 
 /**
- * GET /access/:code
- * Gets ALL boards for an access code in a single request.
+ * GET /access/:slug/:code
+ * Gets ALL boards for a slug + access code pair in a single request.
  * This enables instant frontend navigation without additional requests.
- * Validates code exists and client subscription is active.
+ * Validates slug and code exist, belong together, and client subscription is active.
  * Returns client info (slug, name, color), all boards array, and rootBoardId.
  * Increments viewsCount and updates lastAccessAt on the AccessGate.
  */
 async function getAccessBoard(req, res) {
   const code = req.swagger.params.code.value.toUpperCase();
+  const slug = req.swagger.params.slug.value;
 
   try {
     const now = new Date();
@@ -128,6 +129,7 @@ async function getAccessBoard(req, res) {
     const client = accessGate.accessClient;
     if (
       !client ||
+      client.slug !== slug ||
       !client.isActive ||
       client.subscriptionStart > now ||
       client.subscriptionEnd < now

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -1278,12 +1278,17 @@ paths:
           description: Error
           schema:
             $ref: "#/definitions/ErrorResponse"
-  /access/{code}:
+  /access/{slug}/{code}:
     x-swagger-router-controller: access
     get:
       operationId: getAccessBoard
-      description: Gets ALL boards for an access code in a single request. Validates code exists and subscription is active. Returns client info, all boards array, and rootBoardId.
+      description: Gets ALL boards for an access code in a single request. Validates slug and code exist and subscription is active. Returns client info, all boards array, and rootBoardId.
       parameters:
+        - name: slug
+          type: string
+          in: path
+          required: true
+          description: Client slug (institution identifier)
         - name: code
           type: string
           in: path

--- a/test/postman/CboardAccess.collection.json
+++ b/test/postman/CboardAccess.collection.json
@@ -455,16 +455,17 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{url}}/access/{{access_code}}",
+							"raw": "{{url}}/access/{{client_slug}}/{{access_code}}",
 							"host": [
 								"{{url}}"
 							],
 							"path": [
 								"access",
+								"{{client_slug}}",
 								"{{access_code}}"
 							]
 						},
-						"description": "Public endpoint that retrieves all boards for a specific access code. Used when scanning QR codes or entering access codes. No authentication required."
+						"description": "Public endpoint that retrieves all boards for a slug + access code pair. Used when scanning QR codes or entering access codes. No authentication required."
 					},
 					"response": []
 				}


### PR DESCRIPTION
Changed Access endpoint to `/access/:slug/:code`

**Changes:**
 1. `api/swagger/swagger.yaml` — Route changed from `/access/{code}` to `/access/{slug}/{code}`, added slug as a required path parameter.
 2. `api/controllers/access.js` — `getAccessBoard` now:                                                                                                                                               
    - Extracts slug from `req.swagger.params.slug.value`                                                                                                                                             
    - Validates `client.slug !== slug` — returns 404 if the slug doesn't match the access gate's client (same 404 as other invalid-code cases, so no information leakage)
  3. `test/postman/CboardAccess.collection.json` — GET board URL updated to `{{url}}/access/{{client_slug}}/{{access_code}}` with the path array updated to match. The `client_slug` variable is already saved by the earlier POST request in the collection.