### PR TITLE
Populate boards and communicators only on login

### DIFF
--- a/api/controllers/languages.js
+++ b/api/controllers/languages.js
@@ -9,8 +9,7 @@ const listLanguage = async (req, res) => {
   const laguages = await paginatedResponse(
     LanguagesModel,
     {
-      query,
-      populate: ['communicators', 'boards']
+      query
     },
     req.query
   );

--- a/api/controllers/user.js
+++ b/api/controllers/user.js
@@ -42,6 +42,15 @@ const USER_MODEL_ID_TYPE = {
   apple: 'apple.id'
 };
 
+function mapLeanBoardIds(boards) {
+  if (!Array.isArray(boards)) return boards;
+  return boards.map(board => {
+    if (!board || typeof board !== 'object' || !board._id) return board;
+    const { _id, __v, ...rest } = board;
+    return { ...rest, id: _id };
+  });
+}
+
 async function getSettings(user) {
   let settings = null;
 
@@ -151,12 +160,16 @@ async function passportLogin(ip, type, accessToken, refreshToken, profile, done)
     const propertyId = USER_MODEL_ID_TYPE[type];
     let user = await User.findOne({ [propertyId]: profile.id })
       .populate('communicators')
-      .populate('boards')
+     .populate({ path: 'boards', options: { lean: true } })
       .exec();
 
 
     if (!user) {
       user = await createOrUpdateUser(accessToken, profile, type);
+      await user
+        .populate('communicators')
+        .populate({ path: 'boards', options: { lean: true } })
+        .execPopulate();
     }
 
     if (!user.location || !user.location.country)
@@ -175,8 +188,10 @@ async function passportLogin(ip, type, accessToken, refreshToken, profile, done)
     const settings = await getSettings(user);
     const subscriber = await getSubscriber(user);
 
+    const userJSON = user.toJSON();
+    userJSON.boards = mapLeanBoardIds(userJSON.boards);
     const response = {
-      ...user.toJSON(),
+      ...userJSON,
       settings,
       subscriber,
       authToken: tokenString
@@ -316,8 +331,7 @@ async function listUser(req, res) {
   const response = await paginatedResponse(
     User,
     {
-      query,
-      populate: ['communicators', 'boards']
+      query
     },
     req.query
   );
@@ -341,10 +355,7 @@ async function getUser(req, res) {
   const id = req.swagger.params.id.value;
 
   try {
-    const user = await User.findById(id)
-      .populate('communicators')
-      .populate('boards')
-      .exec();
+    const user = await User.findById(id).exec();
 
     if (!user) {
       return res.status(404).json({
@@ -386,8 +397,6 @@ function updateUser(req, res) {
   }
 
   User.findById(id)
-    .populate('communicators')
-    .populate('boards')
     .exec(async function (err, user) {
       if (err) {
         return res.status(500).json({
@@ -461,8 +470,10 @@ function loginUser(req, res) {
       const settings = await getSettings(user);
       const subscriber = await getSubscriber(user);
 
+      const userJSON = user.toJSON();
+      userJSON.boards = mapLeanBoardIds(userJSON.boards);
       const response = {
-        ...user.toJSON(),
+        ...userJSON,
         settings,
         subscriber,
         birthdate: moment(user.birthdate).format('YYYY-MM-DD'),

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -199,19 +199,6 @@ userSchema.pre('save', function(next) {
 });
 
 /**
- * Post-save hook
- */
-userSchema.post('save', function(doc, next) {
-  doc
-    .populate('communicators')
-    .populate('boards')
-    .execPopulate()
-    .then(function() {
-      next();
-    });
-});
-
-/**
  * Methods
  */
 
@@ -231,23 +218,6 @@ userSchema.methods = {
 
 userSchema.statics = {
   /**
-   * Load
-   *
-   * @param {Object} options
-   * @param {Function} cb
-   * @api private
-   */
-
-  load: function(options, cb) {
-    options.select = options.select || 'name email';
-    return this.findOne(options.criteria)
-      .select(options.select)
-      .populate('communicators')
-      .populate('boards')
-      .exec(cb);
-  },
-
-  /**
    * Authenticate input against database
    *
    * @param {String} email
@@ -258,7 +228,7 @@ userSchema.statics = {
   authenticate: function(email, password, callback) {
     this.findOne({ email: email })
       .populate('communicators')
-      .populate('boards')
+      .populate({ path: 'boards', options: { lean: true } })
       .exec(function(err, user) {
         if (err) {
           return callback(err);
@@ -292,10 +262,7 @@ userSchema.statics = {
     let user = null;
 
     try {
-      user = await this.findById(id)
-        .populate('communicators')
-        .populate('boards')
-        .exec();
+      user = await this.findById(id).exec();
     } catch (e) {}
 
     return user ? user.toJSON() : null;

--- a/test/controllers/user.js
+++ b/test/controllers/user.js
@@ -105,6 +105,29 @@ describe('User API calls', function () {
         })
       });
     });
+
+    it('it should return the user communicators and boards', async function () {
+      const userEmail = helper.generateEmail();
+      await helper.prepareUser(server, {
+        role: 'user',
+        email: userEmail,
+      });
+      const userData = {
+        ...helper.userData,
+        email: userEmail,
+      };
+
+      const res = await request(server)
+        .post('/user/login')
+        .send(userData)
+        .expect('Content-Type', /json/)
+        .expect(200);
+
+      res.body.should.to.have.property('communicators');
+      res.body.communicators.should.be.an('array');
+      res.body.should.to.have.property('boards');
+      res.body.boards.should.be.an('array');
+    });
   });
 
   describe('GET /user', function () {


### PR DESCRIPTION
Closes #463

## Summary

The `boards` and `communicators` `User` virtuals were being populated in several flows that don't need them. Populating `boards` hydrates **all** of a user's boards, which is expensive (hundreds of ms for users with many boards) and was happening on requests that don't even return that data.

This PR keeps the populate **only on the logins** (where the frontend needs the full user) and removes it everywhere else.

## Changes

**`api/models/User.js`**
- Removed the `post('save')` hook that populated `boards`/`communicators` on **every** `user.save()` (location updates, `updateUser`, OAuth creation…). Biggest win.
- Removed the unused `load` static — dead code from the boilerplate, no callers in the repo.

**`api/controllers/user.js`**
- Removed populate from `listUser` (admin list), `getUser` (detail) and `updateUser`.
- In `passportLogin`, populate the **new-user path** as well, so the first OAuth login returns the same shape (`communicators`/`boards` as arrays) as an existing user.

**`api/controllers/languages.js`**
- Removed `populate: ['communicators', 'boards']` from `listLanguage` — the `Languages` model has no such virtuals, so it was a silent no-op (copy-paste).

## Kept (login only)

- `User.authenticate` — email/password login.
- `passportLogin` — Facebook/Google/Apple login (both existing and first-time users).

## Notes

- `updateUser` and the OAuth update path no longer return `communicators`/`boards` in their response (previously injected by the `post('save')` hook). Per the requirement, that data is only needed at login.