### PR TITLE
feat(board): add board sync list and bulk fetch by ids endpoints

### DIFF
--- a/api/controllers/board.js
+++ b/api/controllers/board.js
@@ -10,6 +10,9 @@ const { processBase64Images, hasBase64Images } = require('../helpers/imageProces
 const {nev} = require('../mail');
 
 const BLOB_CONTAINER_NAME = process.env.BLOB_CONTAINER_NAME || 'cblob';
+// Upper bound on ids per /board/byids request. Guards against runaway clients
+// (e.g. a copy-loop bug) without limiting any healthy user.
+const MAX_BOARDS_BY_IDS = 3000;
 
 module.exports = {
   createBoard: createBoard,
@@ -18,6 +21,8 @@ module.exports = {
   getBoard: getBoard,
   updateBoard: updateBoard,
   getBoardsEmail: getBoardsEmail,
+  getBoardsSync: getBoardsSync,
+  getBoardsByIds: getBoardsByIds,
   getPublicBoards: getPublicBoards,
   reportPublicBoard: reportPublicBoard,
   getCbuilderBoard: getCbuilderBoard
@@ -71,6 +76,75 @@ async function getBoardsEmail(req, res) {
   );
 
   return res.status(200).json(response);
+}
+
+
+async function getBoardsSync(req, res) {
+  const email = req.swagger.params.email.value;
+
+  if (!req.user.isAdmin && req.user.email !== email) {
+    return res.status(403).json({
+      message: "You are not authorized to get this user's boards."
+    });
+  }
+
+  try {
+    const boards = await Board.find({ email })
+      .select('lastEdited')
+      .lean()
+      .exec();
+
+    const data = boards.map(b => ({
+      id: b._id,
+      lastEdited: b.lastEdited
+    }));
+
+    return res.status(200).json({ total: data.length, data });
+  } catch (err) {
+    return res.status(500).json({
+      message: 'Error getting boards for sync.',
+      error: err.message
+    });
+  }
+}
+
+async function getBoardsByIds(req, res) {
+  // Shape and non-empty are validated by swagger. The size cap is enforced
+  // here because swagger does not validate array maxItems for request bodies.
+  const { ids } = req.swagger.params.body.value;
+
+  if (ids.length > MAX_BOARDS_BY_IDS) {
+    return res.status(400).json({
+      message: `ids cannot contain more than ${MAX_BOARDS_BY_IDS} items.`
+    });
+  }
+
+  const validIds = ids.filter(id => ObjectId.isValid(id));
+  if (!validIds.length) {
+    return res.status(400).json({
+      message: 'ids must contain at least one valid board id.'
+    });
+  }
+
+  try {
+    const query = { _id: { $in: validIds } };
+
+    if (!req.user.isAdmin) {
+      query.email = req.user.email;
+    }
+
+    const boards = await Board.find(query).lean().exec();
+
+    // Normalize _id -> id to match the rest of the API surface.
+    const data = boards.map(({ _id, ...rest }) => ({ ...rest, id: _id }));
+
+    return res.status(200).json({ total: data.length, data });
+  } catch (err) {
+    return res.status(500).json({
+      message: 'Error getting boards by ids.',
+      error: err.message
+    });
+  }
 }
 
 async function getPublicBoards(req, res) {

--- a/api/models/Board.js
+++ b/api/models/Board.js
@@ -81,6 +81,10 @@ const BOARD_SCHEMA_OPTIONS = {
 
 const boardSchema = new Schema(BOARD_SCHEMA_DEFINITION, BOARD_SCHEMA_OPTIONS);
 
+
+boardSchema.index({ email: 1 });
+boardSchema.index({ email: 1, lastEdited: 1, _id: 1 });
+
 const validatePresenceOf = value => value && value.length;
 
 /**

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -218,6 +218,37 @@ paths:
           description: Error
           schema:
             $ref: "#/definitions/ErrorResponse"
+  /board/byids:
+    x-swagger-router-controller: board
+    post:
+      operationId: getBoardsByIds
+      description: >-
+        Returns the full boards matching the provided ids. Non-admin users only
+        receive boards they own. Invalid ids are ignored.
+      security:
+        - Bearer: []
+      x-security-scopes:
+        - admin
+        - user
+      parameters:
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: "#/definitions/BoardsByIdsRequest"
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/GetBoardsByIdsResponse"
+        "400":
+          description: Bad request
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+        default:
+          description: Error
+          schema:
+            $ref: "#/definitions/ErrorResponse"
   /board/{id}:
     x-swagger-router-controller: board
     get:
@@ -318,6 +349,38 @@ paths:
           description: Success
           schema:
             $ref: "#/definitions/GetBoardListResponse"
+        default:
+          description: Error
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+  /board/sync/{email}:
+    x-swagger-router-controller: board
+    get:
+      operationId: getBoardsSync
+      description: >-
+        Returns a lightweight list ({ id, lastEdited }) of every board for a
+        user email. Meant for sync: the client compares against its local copy
+        and fetches only changed boards via GET /board/{id}.
+      security:
+        - Bearer: []
+      x-security-scopes:
+        - admin
+        - user
+      parameters:
+        - name: email
+          type: string
+          in: path
+          required: true
+          minimum: 1
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/GetBoardsSyncResponse"
+        "403":
+          description: Not authorized
+          schema:
+            $ref: "#/definitions/ErrorResponse"
         default:
           description: Error
           schema:
@@ -1843,6 +1906,48 @@ definitions:
         type: string
       search:
         type: string
+      data:
+        type: array
+        items:
+          $ref: "#/definitions/Board"
+  GetBoardsSyncResponse:
+    required:
+      - total
+      - data
+    properties:
+      total:
+        type: integer
+      data:
+        type: array
+        items:
+          type: object
+          required:
+            - id
+            - lastEdited
+          properties:
+            id:
+              type: string
+            lastEdited:
+              type: string
+              format: date-time
+  BoardsByIdsRequest:
+    type: object
+    required:
+      - ids
+    properties:
+      ids:
+        type: array
+        minItems: 1
+        maxItems: 3000
+        items:
+          type: string
+  GetBoardsByIdsResponse:
+    required:
+      - total
+      - data
+    properties:
+      total:
+        type: integer
       data:
         type: array
         items:

--- a/test/controllers/board.js
+++ b/test/controllers/board.js
@@ -292,4 +292,164 @@ describe('Board API calls', function () {
         .expect(200);
     });
   });
+
+  describe('GET /board/sync/:email', function () {
+    // beforeEach (not before) so the board is created for the user set up by
+    // the parent beforeEach, which runs first and regenerates the test email.
+    beforeEach(async function () {
+      this.boardId = await helper.createMochaBoard(server, user.token);
+    });
+
+    it('it should return a lightweight { id, lastEdited } list', async function () {
+      const res = await request(server)
+        .get(`/board/sync/${encodeURI(helper.boardData.email)}`)
+        .set('Authorization', `Bearer ${user.token}`)
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200);
+
+      res.body.should.have.property('total').that.is.a('number');
+      res.body.should.have.property('data').that.is.an('array');
+      res.body.data.length.should.be.above(0);
+      res.body.data.forEach((entry) => {
+        entry.should.have.all.keys('id', 'lastEdited');
+      });
+      const ids = res.body.data.map((entry) => entry.id);
+      expect(ids).to.include(this.boardId);
+    });
+
+    it('it should NOT return the sync list without authorization', async function () {
+      await request(server)
+        .get(`/board/sync/${encodeURI(helper.boardData.email)}`)
+        .set('Accept', 'application/json')
+        .expect(403);
+    });
+
+    it("only allows an admin to get another user's sync list", async function () {
+      const adminEmail = helper.generateEmail();
+      const admin = await helper.prepareUser(server, {
+        role: 'admin',
+        email: adminEmail,
+      });
+
+      const otherEmail = helper.generateEmail();
+      const otherUser = await helper.prepareUser(server, {
+        role: 'user',
+        email: otherEmail,
+      });
+
+      // A non-admin requesting someone else's sync list is rejected.
+      await request(server)
+        .get(`/board/sync/${encodeURI(helper.boardData.email)}`)
+        .set('Authorization', `Bearer ${otherUser.token}`)
+        .expect({
+          message: "You are not authorized to get this user's boards.",
+        })
+        .expect(403);
+
+      // An admin can request any user's sync list.
+      await request(server)
+        .get(`/board/sync/${encodeURI(helper.boardData.email)}`)
+        .set('Authorization', `Bearer ${admin.token}`)
+        .expect(200);
+    });
+  });
+
+  describe('POST /board/byids', function () {
+    let boardId1;
+    let boardId2;
+
+    // beforeEach (not before) so the boards belong to the user set up by the
+    // parent beforeEach, which runs first and regenerates the test email.
+    beforeEach(async function () {
+      boardId1 = await helper.createMochaBoard(server, user.token);
+      boardId2 = await helper.createMochaBoard(server, user.token);
+    });
+
+    it('it should return the requested boards', async function () {
+      const res = await request(server)
+        .post('/board/byids')
+        .send({ ids: [boardId1, boardId2] })
+        .set('Authorization', `Bearer ${user.token}`)
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200);
+
+      res.body.should.have.property('total', 2);
+      res.body.should.have.property('data').that.is.an('array');
+      res.body.data.should.have.lengthOf(2);
+      res.body.data.forEach((board) => helper.verifyBoardProperties(board));
+      const returnedIds = res.body.data.map((b) => b.id);
+      expect(returnedIds).to.have.members([boardId1, boardId2]);
+    });
+
+    it('it should ignore invalid ObjectIds and return only valid matches', async function () {
+      const res = await request(server)
+        .post('/board/byids')
+        .send({ ids: [boardId1, 'not-a-valid-object-id'] })
+        .set('Authorization', `Bearer ${user.token}`)
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200);
+
+      res.body.should.have.property('total', 1);
+      res.body.data.should.have.lengthOf(1);
+      res.body.data[0].should.have.property('id', boardId1);
+    });
+
+    it('it should return 400 when ids contains only invalid ObjectIds', async function () {
+      await request(server)
+        .post('/board/byids')
+        .send({ ids: ['not-a-valid-object-id'] })
+        .set('Authorization', `Bearer ${user.token}`)
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(400);
+    });
+
+    it('it should return 400 for an empty ids array', async function () {
+      await request(server)
+        .post('/board/byids')
+        .send({ ids: [] })
+        .set('Authorization', `Bearer ${user.token}`)
+        .set('Accept', 'application/json')
+        .expect(400);
+    });
+
+    it('it should return 400 when ids exceeds the maximum allowed', async function () {
+      const ids = Array.from({ length: 3001 }, () => boardId1);
+      await request(server)
+        .post('/board/byids')
+        .send({ ids })
+        .set('Authorization', `Bearer ${user.token}`)
+        .set('Accept', 'application/json')
+        .expect(400);
+    });
+
+    it('it should NOT return boards without authorization', async function () {
+      await request(server)
+        .post('/board/byids')
+        .send({ ids: [boardId1] })
+        .set('Accept', 'application/json')
+        .expect(403);
+    });
+
+    it("it should not return another user's boards to a non-admin", async function () {
+      const otherUser = await helper.prepareUser(server, {
+        role: 'user',
+        email: helper.generateEmail(),
+      });
+
+      const res = await request(server)
+        .post('/board/byids')
+        .send({ ids: [boardId1, boardId2] })
+        .set('Authorization', `Bearer ${otherUser.token}`)
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200);
+
+      res.body.should.have.property('total', 0);
+      res.body.data.should.have.lengthOf(0);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Adds the backend needed for efficient diff-based board sync, supporting the frontend work in cboard-org/cboard#2213 (PR cboard-org/cboard#2214).

Instead of fetching every board in full or calling `GET /board/{id}` once per board (N round-trips), a client can now:

1. Call **`GET /board/sync/{email}`** → get a lightweight `{ id, lastEdited }` list of all the user's boards.
2. Diff it against its local copy to find which boards changed.
3. Call **`POST /board/byids`** with just the changed ids → fetch those full boards in a single request.

## Changes

- **`GET /board/sync/{email}`** (`getBoardsSync`) — lightweight change list.
- **`POST /board/byids`** (`getBoardsByIds`) — bulk fetch full boards by id.
- **`Board` model** — indexes on `email` and `{ email, lastEdited, _id }` to back the sync queries.
- Swagger definitions for both endpoints (`BoardsByIdsRequest`, `GetBoardsByIdsResponse`).
- Controller tests for both endpoints.

## Security / safety

- Both endpoints require a Bearer token (`admin` / `user` scopes).
- Non-admin callers are scoped to their own boards by `email`.
- `POST /board/byids` filters out invalid ObjectIds and caps the request at **3000 ids**, enforced in the controller — swagger does not validate array `maxItems` on request bodies, so the cap must live in code.

## Notes for reviewers

- `/board/byids` is declared in the swagger spec **before** `/board/{id}` so the literal path resolves ahead of the `{id}` template under swagger-tools routing. Keep that ordering.
- This swagger setup does not enforce array `minItems`/`maxItems` on bodies; size/shape constraints are validated in the controller.

## Test plan

- [ ] `npm test` (board controller suite) — auth, admin-only access to other users' data, ObjectId filtering, size cap, non-admin isolation.

Refs cboard-org/cboard#2213, cboard-org/cboard#2214
Closes #465