### PR TITLE
feat(board): add userId field to track board ownership

### DIFF
--- a/api/controllers/board.js
+++ b/api/controllers/board.js
@@ -23,10 +23,10 @@ module.exports = {
   getCbuilderBoard: getCbuilderBoard
 };
 
-// TODO: Use the caller's email instead of getting it from the body.
 function createBoard(req, res) {
   const board = new Board(req.body);
   board.lastEdited = moment().format();
+  board.userId = req.auth.id;
   board.save(function (err, board) {
     if (err) {
       return res.status(409).json({
@@ -89,17 +89,27 @@ async function getPublicBoards(req, res) {
 
 async function deleteBoard(req, res) {
   const id = req.swagger.params.id.value;
+
+  const board = await Board.findById(id);
+
+  if (!board) {
+    return res.status(404).json({
+      message: 'Board not found. Board Id: ' + id,
+      error: 'Board not found.'
+    });
+  }
+
+  if (!req.user.isAdmin && board.userId && board.userId.toString() !== req.auth.id) {
+    return res.status(403).json({
+      message: 'You are not authorized to delete this board.'
+    });
+  }
+
   Board.findByIdAndRemove(id, function (err, boards) {
     if (err) {
       return res.status(404).json({
         message: 'Board not found. Board Id: ' + id,
         error: err.message
-      });
-    }
-    if (!boards) {
-      return res.status(404).json({
-        message: 'Board not found. Board Id: ' + id,
-        error: 'Board not found.'
       });
     }
     return res.status(200).json(boards);
@@ -140,6 +150,12 @@ async function updateBoard(req, res) {
     if (!board) {
       return res.status(404).json({
         message: 'Unable to find board. board Id: ' + id
+      });
+    }
+
+    if (!req.user.isAdmin && board.userId && board.userId.toString() !== req.auth.id) {
+      return res.status(403).json({
+        message: 'You are not authorized to update this board.'
       });
     }
     

--- a/api/models/Board.js
+++ b/api/models/Board.js
@@ -23,6 +23,12 @@ const BOARD_SCHEMA_DEFINITION = {
     required: true,
     trim: true
   },
+  userId: {
+    type: Schema.Types.ObjectId,
+    ref: 'User',
+    required: false,
+    index: true
+  },
   isPublic: {
     type: Boolean,
     default: false

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -1471,6 +1471,9 @@ definitions:
         type: string
       email:
         type: string
+      userId:
+        type: string
+        description: The ID of the user who owns this board
       tiles:
         type: array
         items:

--- a/test/controllers/board.js
+++ b/test/controllers/board.js
@@ -199,7 +199,7 @@ describe('Board API calls', function () {
         .expect(404);
     });
 
-    it.skip("returns a 404 if the caller is not an admin and doesn't own the board", async function () {
+    it("returns a 403 if the caller is not an admin and doesn't own the board", async function () {
       const email = helper.generateEmail();
       const user1 = await helper.prepareUser(server, { email });
       const user2 = await helper.prepareUser(server, {
@@ -222,10 +222,10 @@ describe('Board API calls', function () {
         .set('Authorization', `Bearer ${user2.token}`)
         .set('Accept', 'application/json')
         .expect('Content-Type', /json/)
-        .expect(404);
+        .expect(403);
     });
 
-    it.skip("deletes the board if the caller is an admin but doesn't own the board", async function () {
+    it("deletes the board if the caller is an admin but doesn't own the board", async function () {
       const email = helper.generateEmail();
       const user1 = await helper.prepareUser(server, { email });
       const user2 = await helper.prepareUser(server, {

--- a/test/helper.js
+++ b/test/helper.js
@@ -61,6 +61,7 @@ const verifyBoardProperties = (body) => {
   body.should.have.property('name');
   body.should.have.property('author');
   body.should.have.property('email');
+  body.should.have.property('userId');
   body.should.have.property('isPublic');
   body.should.have.property('tiles');
 };


### PR DESCRIPTION
Closes #140

### Summary

Add a `userId` field (ObjectId ref to User) to the Board model so that ownership is tied to a stable user identifier instead of just the email string. This is the first step toward allowing users to change their email without losing access to their boards.

### Changes

| File | Change |
|------|--------|
| `api/models/Board.js` | Added `userId` field (ObjectId, ref: 'User', indexed) |
| `api/controllers/board.js` | Set `userId` from JWT token on create; add ownership checks on delete/update |
| `api/swagger/swagger.yaml` | Added optional `userId` property to Board schema |
| `test/helper.js` | Added `userId` to `verifyBoardProperties` assertion |
| `test/controllers/board.js` | Enabled two previously skipped ownership tests |

### Test Plan

- Existing tests pass (POST/GET/PUT/DELETE board)
- Ownership checks now enforce that non-admin users can only modify their own boards
- Admin users can still modify any board

### Notes

- `userId` is optional (`required: false`) for backward compatibility with existing boards that don't have it yet. A migration script to backfill existing boards is tracked as a follow-up.
- `userId` is `index: true` for performant lookups.