### PR TITLE
fix(board): avoid Mongoose VersionError on board update after sync

### DIFF
--- a/api/controllers/board.js
+++ b/api/controllers/board.js
@@ -219,8 +219,6 @@ async function updateBoard(req, res) {
     
     const updateData = { ...req.body };
     delete updateData.__v;
-    delete updateData._id;
-    delete updateData.id;
 
     if (
       updateData.tiles &&

--- a/api/controllers/board.js
+++ b/api/controllers/board.js
@@ -135,8 +135,8 @@ async function getBoardsByIds(req, res) {
 
     const boards = await Board.find(query).lean().exec();
 
-    // Normalize _id -> id to match the rest of the API surface.
-    const data = boards.map(({ _id, ...rest }) => ({ ...rest, id: _id }));
+    // Normalize _id -> id and drop the Mongoose version key to match the toJSON() output 
+    const data = boards.map(({ _id, __v, ...rest }) => ({ ...rest, id: _id }));
 
     return res.status(200).json({ total: data.length, data });
   } catch (err) {
@@ -218,7 +218,10 @@ async function updateBoard(req, res) {
     }
     
     const updateData = { ...req.body };
-    
+    delete updateData.__v;
+    delete updateData._id;
+    delete updateData.id;
+
     if (
       updateData.tiles &&
       Array.isArray(updateData.tiles) &&

--- a/test/controllers/board.js
+++ b/test/controllers/board.js
@@ -113,6 +113,32 @@ describe('Board API calls', function () {
       helper.verifyBoardProperties(res.body);
     });
 
+    it('it should PUT a board even when the body carries a stale __v (no VersionError)', async function () {
+      // Simulates an older client that cached the board with the Mongoose
+      // version key and echoes __v/_id/id back on update. The server must
+      // ignore them instead of overwriting the real version and throwing a
+      // VersionError on save.
+      const boardData = {
+        ...helper.boardData,
+        __v: 999,
+        _id: this.boardId,
+        name: 'edited with stale version',
+        tiles: [{ label: 'changed' }],
+      };
+
+      const res = await request(server)
+        .put('/board/' + this.boardId)
+        .send(boardData)
+        .set('Authorization', `Bearer ${user.token}`)
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200);
+
+      helper.verifyBoardProperties(res.body);
+      res.body.should.have.property('name', 'edited with stale version');
+      res.body.should.not.have.property('__v');
+    });
+
     it('it should NOT PUT a board without ID', async function () {
       const boardData = { ...helper.boardData };
       await request(server)
@@ -381,6 +407,23 @@ describe('Board API calls', function () {
       res.body.data.forEach((board) => helper.verifyBoardProperties(board));
       const returnedIds = res.body.data.map((b) => b.id);
       expect(returnedIds).to.have.members([boardId1, boardId2]);
+    });
+
+    it('it should not expose the Mongoose _id/__v keys', async function () {
+      // Leaking __v here is what caused clients to echo a stale version back on
+      // update, triggering a VersionError. Boards must be normalized to `id`.
+      const res = await request(server)
+        .post('/board/byids')
+        .send({ ids: [boardId1] })
+        .set('Authorization', `Bearer ${user.token}`)
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200);
+
+      res.body.data.should.have.lengthOf(1);
+      res.body.data[0].should.have.property('id', boardId1);
+      res.body.data[0].should.not.have.property('__v');
+      res.body.data[0].should.not.have.property('_id');
     });
 
     it('it should ignore invalid ObjectIds and return only valid matches', async function () {


### PR DESCRIPTION
## Summary

Fixes a `VersionError` that broke board saves (`PUT /board/{id}`) after the board-sync feature:

```
Error saving board. -> No matching document found for id "..." version 1 modifiedPaths "tiles, lastEdited"
```

`getBoardsByIds` leaked the Mongoose `__v` version key to clients (lean queries skip the `toJSON` transform that sets `versionKey: false`). Clients cached the board with `__v` and sent it back on update; `updateBoard` then overwrote the real `__v` with the stale client value, so `save()`'s optimistic-concurrency guard no longer matched the DB and threw.

## Changes

- **`getBoardsByIds`**: drop `__v` in the `_id -> id` normalization, matching what `mapLeanBoardIds` already does on login.
- **`updateBoard`**: strip `__v`, `_id` and `id` from the request body so the server never trusts the client's version. This also recovers **already-affected clients** that still have `__v` cached locally, without requiring a cache clear.

## Notes

- Login was already safe via `mapLeanBoardIds`.
- `getBoardsSync` was already safe (returns only `id` and `lastEdited`).

## Testing

- Reproduced the `VersionError` by sending a stale `__v` in the update body; with the fix the save returns `200`.

Closes #469

🤖 Generated with [Claude Code](https://claude.com/claude-code)