### PR TITLE
fix(cors): expose Request-Context header for App Insights correlation

### DIFF
--- a/app.js
+++ b/app.js
@@ -54,7 +54,8 @@ swaggerTools.initializeMiddleware(swaggerConfig, async function (middleware) {
         process.env.CBOARD_APP_URL,
         process.env.CBOARD_IOS_APP_URL,
         process.env.CBUILDER_APP_URL
-      ]
+      ],
+      exposedHeaders: ['Request-Context']
     })
   );
 


### PR DESCRIPTION
## Summary

Adds `exposedHeaders: ['Request-Context']` to the cors configuration so cross-origin clients can read the App Insights `Request-Context` response header.

Closes #472 (API side).

## Why

The Node App Insights SDK stamps every response with `Request-Context: appId=...`, which the browser SDK uses to attribute its dependency telemetry to the "Cboard API" component on the Application Map. CORS only lets cross-origin JavaScript read response headers explicitly listed in `Access-Control-Expose-Headers`, so without this change the header is invisible to the web app and the API shows up as an unmonitored external dependency.

No `allowedHeaders` list was added on purpose: the `cors` middleware currently reflects the preflight's `Access-Control-Request-Headers`, which already permits `traceparent`/`Request-Id` on incoming requests — pinning an explicit list could only break callers.

## Companion change

Full client↔server correlation also needs the frontend to stop excluding the API domain from correlation headers: revert `'*.cboard.io'` back to `'cbuilder.cboard.io'` in `src/appInsights.js` (cboard-org/cboard@5ea5084). Rollout order: deploy this PR first (additive, cannot break existing clients), then the frontend change against QA.

## Testing

- Additive header change only; no behavioral change for existing clients.
- After deploy, verify a response includes `Access-Control-Expose-Headers: Request-Context` and that browser/server telemetry share one `operation_Id` once the frontend change lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)