### PR TITLE
Created endpoint createAccessGate

### DIFF
--- a/api/controllers/access.js
+++ b/api/controllers/access.js
@@ -8,6 +8,7 @@ module.exports = {
   getClients: getClients,
   getAccessBoards: getAccessBoards,
   createAccessClient: createAccessClient,
+  createAccessGate: createAccessGate,
   listAccessClients: listAccessClients,
   updateAccessClient: updateAccessClient,
   updateAccessGate: updateAccessGate,
@@ -336,6 +337,62 @@ async function listAccessClients(req, res) {
   } catch (err) {
     return res.status(500).json({
       message: 'Error listing clients',
+      error: err.message
+    });
+  }
+}
+
+/**
+ * POST /admin/access/clients/:clientSlug/gates
+ * Adds a new AccessGate to an existing Access client.
+ * Requires admin authentication (enforced by Swagger middleware).
+ * Auto-discovers linked boards from rootBoardId and marks them with accessGateCode.
+ */
+async function createAccessGate(req, res) {
+  const slug = req.swagger.params.clientSlug.value;
+  const { accessGateCode, rootBoardId } = req.body;
+
+  try {
+    const client = await AccessClient.findOne({ slug });
+    if (!client) {
+      return res.status(404).json({ message: 'Client not found' });
+    }
+
+    const rootBoard = await Board.findById(rootBoardId);
+    if (!rootBoard) {
+      return res.status(404).json({ message: 'Root board not found' });
+    }
+
+    const existingCode = await AccessGate.findOne({
+      code: accessGateCode.toUpperCase()
+    });
+    if (existingCode) {
+      return res.status(409).json({ message: 'Code already exists' });
+    }
+
+    const linkedBoardIds = await getAllLinkedBoardIds(rootBoardId);
+
+    const newAccessGate = new AccessGate({
+      code: accessGateCode.toUpperCase(),
+      accessClientId: client._id,
+      rootBoardId,
+      linkedBoardIds
+    });
+
+    await newAccessGate.save();
+
+    await Board.updateMany(
+      { _id: { $in: linkedBoardIds } },
+      { $set: { accessGateCode: newAccessGate.code } }
+    );
+
+    return res.status(201).json(newAccessGate.toJSON());
+  } catch (err) {
+    if (err.code === 11000) {
+      return res.status(409).json({ message: 'Code already exists' });
+    }
+    return res.status(500).json({
+      message: 'Error creating access gate',
       error: err.message
     });
   }

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -1509,6 +1509,43 @@ paths:
           description: Error
           schema:
             $ref: "#/definitions/ErrorResponse"
+  /admin/access/clients/{clientSlug}/gates:
+    x-swagger-router-controller: access
+    post:
+      operationId: createAccessGate
+      description: Adds a new AccessGate to an existing Access client. Auto-discovers linked boards from rootBoardId and marks them with accessGateCode. Requires admin authentication.
+      security:
+        - Bearer: []
+      x-security-scopes:
+        - admin
+      parameters:
+        - name: clientSlug
+          type: string
+          in: path
+          required: true
+          description: Client slug identifier
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: "#/definitions/AccessGateCreate"
+      responses:
+        "201":
+          description: Success - gate created
+          schema:
+            $ref: "#/definitions/AccessGateResponse"
+        "404":
+          description: Client or root board not found
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+        "409":
+          description: Code already exists
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+        default:
+          description: Error
+          schema:
+            $ref: "#/definitions/ErrorResponse"
   /admin/access/gates/{gateCode}:
     x-swagger-router-controller: access
     put:
@@ -2559,6 +2596,19 @@ definitions:
         type: string
         x-nullable: true
         description: The access gate code associated with this board
+  AccessGateCreate:
+    type: object
+    required:
+      - accessGateCode
+      - rootBoardId
+    properties:
+      accessGateCode:
+        type: string
+        description: Unique code for the access gate (will be uppercased)
+        example: EVENTS-B
+      rootBoardId:
+        type: string
+        description: ID of the root board (boards reachable from it are auto-discovered)
   AccessGateResponse:
     type: object
     properties:

--- a/app.js
+++ b/app.js
@@ -54,7 +54,8 @@ swaggerTools.initializeMiddleware(swaggerConfig, async function (middleware) {
         process.env.CBOARD_APP_URL,
         process.env.CBOARD_IOS_APP_URL,
         process.env.CBUILDER_APP_URL
-      ]
+      ],
+      exposedHeaders: ['Request-Context']
     })
   );
 

--- a/test/postman/CboardAccess.README.md
+++ b/test/postman/CboardAccess.README.md
@@ -13,6 +13,7 @@ Cboard Access allows businesses to offer AAC boards in their locations via QR co
 
 ### 2. Admin Endpoints (Require Authentication)
 - **Create Access Client**: Create a new Cboard Access client and its first access gate
+- **Add Access Gate to Client**: Add an independent access gate (with its own code and root board) to an existing client
 - **List All Clients**: View all registered clients with statistics
 - **Update Client**: Modify client information
 - **Deactivate Client**: Disable a client by setting `isActive` to false
@@ -91,6 +92,32 @@ The collection includes these variables (can be edited in collection variables o
 2. The response includes the created client (`slug`, `contact.name`, etc.) and the `accessGate` with `code` and `linkedBoardIds`
 3. `client_slug` and `access_code` variables are automatically saved for subsequent requests
 
+### Adding Independent Access Gates
+
+A single client can have multiple access gates, each with its own code and independent board tree. This is useful when a client needs to offer different board sets (e.g. for different events, rooms, or user groups) under the same subscription.
+
+1. After creating the client, run **Add Access Gate to Client** for each additional gate:
+   ```json
+   {
+     "accessGateCode": "EVENTS-B",
+     "rootBoardId": "{{root_board_id}}"
+   }
+   ```
+
+2. Each gate auto-discovers its own board tree from its `rootBoardId` via tile navigation — independently from other gates
+3. The new `access_code` variable is automatically saved for testing board access
+4. Users access each independent tree by entering or scanning that gate's specific code
+
+**Example — 4 independent board sets for one client:**
+```
+POST /admin/access/clients/events/gates  →  { "accessGateCode": "EVENTS-A", "rootBoardId": "..." }
+POST /admin/access/clients/events/gates  →  { "accessGateCode": "EVENTS-B", "rootBoardId": "..." }
+POST /admin/access/clients/events/gates  →  { "accessGateCode": "EVENTS-C", "rootBoardId": "..." }
+POST /admin/access/clients/events/gates  →  { "accessGateCode": "EVENTS-D", "rootBoardId": "..." }
+```
+
+Each board tree can internally link to other boards via `tile.loadBoard`, but the four trees are completely isolated from each other.
+
 ### Testing the Client
 
 1. **Admin View**: Run "List All Clients" to see all clients with statistics
@@ -125,6 +152,18 @@ Use **Update Access Gate** to re-run board discovery after the board structure c
 - `brandColor`: Hex color code
 
 Board discovery is automatic — all boards reachable from `rootBoardId` via tile navigation are linked to the access gate.
+
+### Add Access Gate to Client
+
+**Endpoint:** `POST /admin/access/clients/:clientSlug/gates`
+
+**Required Fields:**
+- `accessGateCode`: Unique code for this gate (uppercase alphanumeric, e.g. `EVENTS-B`)
+- `rootBoardId`: ID of the root board for this gate's independent board tree
+
+Board discovery is automatic — all boards reachable from `rootBoardId` via tile navigation are linked to this gate. Boards belonging to other gates of the same client are not affected.
+
+Returns the created `AccessGate` object with `code`, `rootBoardId`, and `linkedBoardIds`.
 
 ### Update Client
 
@@ -175,7 +214,14 @@ Each request includes automated tests:
 3. Update to reactivate
 4. Verify it reappears in public listing
 
-### Scenario 4: Board Structure Changed
+### Scenario 4: Client with Multiple Independent Board Sets
+
+1. Create the client with the first gate (via Create Access Client)
+2. Run "Add Access Gate to Client" for each additional independent board set
+3. Verify each gate has its own `linkedBoardIds` via "View Statistics"
+4. Test each gate independently via "Test Public Board Access" with different `access_code` values
+
+### Scenario 5: Board Structure Changed
 
 1. Update boards (add/remove tile navigation)
 2. Run "Update Access Gate" to re-discover linked boards

--- a/test/postman/CboardAccess.collection.json
+++ b/test/postman/CboardAccess.collection.json
@@ -83,6 +83,70 @@
 					"response": []
 				},
 				{
+					"name": "Add Access Gate to Client",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 201\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});",
+									"",
+									"pm.test(\"Response contains access gate data\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData).to.have.property('code');",
+									"    pm.expect(jsonData).to.have.property('rootBoardId');",
+									"    pm.expect(jsonData).to.have.property('linkedBoardIds');",
+									"    pm.expect(jsonData.linkedBoardIds.length).to.be.at.least(1);",
+									"    console.log(\"Gate created: \" + jsonData.code + \" with \" + jsonData.linkedBoardIds.length + \" boards\");",
+									"});",
+									"",
+									"if (pm.response.code === 201) {",
+									"    var jsonData = pm.response.json();",
+									"    pm.collectionVariables.set(\"access_code\", jsonData.code);",
+									"    console.log(\"Access code saved: \" + jsonData.code);",
+									"}"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{token}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"accessGateCode\": \"EVENTS-B\",\n    \"rootBoardId\": \"{{root_board_id}}\"\n}"
+						},
+						"url": {
+							"raw": "{{url}}/admin/access/clients/{{client_slug}}/gates",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"admin",
+								"access",
+								"clients",
+								"{{client_slug}}",
+								"gates"
+							]
+						},
+						"description": "Adds a new independent AccessGate to an existing client. Each gate has its own accessGateCode and rootBoardId. Boards are auto-discovered from the root via tile.loadBoard links. Multiple gates per client allow independent board trees under the same subscription."
+					},
+					"response": []
+				},
+				{
 					"name": "List All Clients",
 					"event": [
 						{


### PR DESCRIPTION
Add independent access gates per client

Added a new endpoint `POST /admin/access/clients/:clientSlug/gates` that allows adding multiple independent access gates to an existing Cboard Access client. Each gate has its own `accessGateCode` and `rootBoardId`, with boards auto-discovered recursively via `tile.loadBoard` links — keeping each board tree fully isolated from the others.

Changes:
- `api/controllers/access.js` — new createAccessGate handler
- `api/swagger/swagger.yaml` — new endpoint + AccessGateCreate schema definition
- `test/postman/CboardAccess.collection.json` — new "Add Access Gate to Client" request with test scripts
- `test/postman/CboardAccess.README.md` — updated docs and usage examples