### PR TITLE
chore(docker): shrink image with multi-stage slim build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,14 @@
-!node_modules
-!package-lock.json
+node_modules
+npm-debug.log
+.git
+.gitignore
+.dockerignore
+Dockerfile
+.env
+.nvmrc
+test
+coverage
+.nyc_output
+*.md
+.vscode
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,19 @@
 # The Node version should always match what's in .nvmrc.
-FROM node:18.18.1
+
+# --- deps stage: install production dependencies only ---
+FROM node:18.18.1-slim AS deps
 WORKDIR /opt/cboard-api/
-COPY . /opt/cboard-api/
+COPY package.json yarn.lock ./
+RUN yarn install --frozen-lockfile --production && yarn cache clean
 
-RUN npm install -g node-gyp 
-RUN npm install -g swagger
-#RUN npm install -g yarn
-RUN yarn install
+# --- runtime stage: slim image with only what's needed to run ---
+FROM node:18.18.1-slim AS runtime
+ENV NODE_ENV=production
+WORKDIR /opt/cboard-api/
 
+COPY --from=deps /opt/cboard-api/node_modules ./node_modules
+COPY . .
+
+USER node
 EXPOSE 80 10010
-CMD [ "yarn", "start"]
+CMD [ "node", "app.js" ]


### PR DESCRIPTION
## Summary

Reworks the `Dockerfile` to significantly reduce the final image size using a multi-stage build.

## Changes

- **Base image**: `node:18.18.1` → `node:18.18.1-slim` (the biggest size win).
- **`deps` stage**: installs production dependencies only (`--production --frozen-lockfile`) and runs `yarn cache clean`.
- **`runtime` stage**: copies only `node_modules` from the `deps` stage, leaving build-time cruft out of the shipped image. Also improves rebuild speed via layer caching (deps are installed before source is copied).
- **Removed** the unused global installs (`node-gyp`, `swagger`) — neither is needed at runtime (`bcryptjs` is pure JS; `req.swagger` comes from the `swagger-*` dependencies, not the global CLI).
- **Security**: runs as the non-root `node` user and starts via `node app.js` directly instead of `yarn start`.
- **`.dockerignore`**: replaced the broken un-ignore rules with a real exclude list, so `node_modules`, `.git`, tests, etc. no longer leak into the build context.

## Testing

- [ ] `docker build -t cboard-api:slim .` completes successfully
- [ ] `docker images cboard-api:slim` shows a reduced size vs the previous full image
- [ ] Container starts and serves requests (requires a reachable MongoDB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)