### PR TITLE
Secures Apple ID token verification

### DIFF
--- a/api/controllers/user.js
+++ b/api/controllers/user.js
@@ -12,6 +12,7 @@ const Settings = require('../models/Settings');
 const { nev } = require('../mail');
 const auth = require('../helpers/auth');
 const { findIpLocation, isLocalIp } = require('../helpers/localize');
+const { verifyAppleIdToken } = require('../helpers/appleAuth');
 const Subscribers = require('../models/Subscribers');
 
 const config = require('../../config');
@@ -215,7 +216,21 @@ async function googleLogin(req, accessToken, refreshToken, profile, done) {
 }
 
 async function appleLogin(req, accessToken, refreshToken, idToken, profile, done) {
-  const decodedUser = jwt.decode(idToken);
+  let decodedUser;
+  try {
+    // Accept both the native app bundle id and the web Services id as valid
+    // audiences, since Apple sets `aud` to whichever client initiated sign-in.
+    const audiences = [
+      process.env.APPLE_APP_CLIENT_ID,
+      `${process.env.APPLE_TEAM_ID}.${process.env.APPLE_APP_CLIENT_ID}`
+    ].filter(Boolean);
+
+    decodedUser = await verifyAppleIdToken(idToken, audiences);
+  } catch (err) {
+    console.error('Apple identity token verification failed:', err.message);
+    return done(new Error('Invalid Apple identity token'));
+  }
+
   const appleProfile = {
     id: decodedUser.sub,
     accessToken: accessToken,

--- a/api/helpers/appleAuth.js
+++ b/api/helpers/appleAuth.js
@@ -1,0 +1,56 @@
+const crypto = require('crypto');
+const axios = require('axios');
+const jwt = require('jsonwebtoken');
+
+const APPLE_ISSUER = 'https://appleid.apple.com';
+const APPLE_KEYS_URL = 'https://appleid.apple.com/auth/keys';
+// Apple rotates its signing keys, so cache them for a limited time instead of
+// fetching on every login.
+const KEYS_TTL_MS = 24 * 60 * 60 * 1000; // 24h
+
+let cachedKeys = null;
+let cachedKeysExpiry = 0;
+
+async function getApplePublicKeys() {
+  const now = Date.now();
+  if (cachedKeys && now < cachedKeysExpiry) {
+    return cachedKeys;
+  }
+
+  const { data } = await axios.get(APPLE_KEYS_URL);
+  cachedKeys = (data && data.keys) || [];
+  cachedKeysExpiry = now + KEYS_TTL_MS;
+  return cachedKeys;
+}
+
+// Verifies the signature and standard claims of an Apple identity token against
+// Apple's published public keys. Returns the decoded payload when valid and
+// throws otherwise, so callers must never trust an unverified token.
+async function verifyAppleIdToken(idToken, audiences) {
+  if (!idToken || typeof idToken !== 'string') {
+    throw new Error('Missing Apple identity token');
+  }
+
+  const decoded = jwt.decode(idToken, { complete: true });
+  if (!decoded || !decoded.header || !decoded.header.kid) {
+    throw new Error('Invalid Apple identity token');
+  }
+
+  const keys = await getApplePublicKeys();
+  const jwk = keys.find(key => key.kid === decoded.header.kid);
+  if (!jwk) {
+    throw new Error('No matching Apple public key found for token');
+  }
+
+  const publicKey = crypto.createPublicKey({ key: jwk, format: 'jwk' });
+
+  return jwt.verify(idToken, publicKey, {
+    algorithms: ['RS256'],
+    issuer: APPLE_ISSUER,
+    audience: audiences
+  });
+}
+
+module.exports = {
+  verifyAppleIdToken
+};


### PR DESCRIPTION
Implements robust verification of Apple ID tokens during the login process.

- Adds a new helper module for Apple authentication logic.
- Fetches and caches Apple's public signing keys to cryptographically validate `idToken` signatures.
- Verifies the token's issuer, audience (including both native app and web service client IDs), and algorithm.
- Replaces simple token decoding with comprehensive signature and claim validation in the Apple login flow.
- Enhances error handling for invalid or unverified tokens.