### PR TITLE
Adds configurable JWT expiration

### DIFF
--- a/api/helpers/auth.js
+++ b/api/helpers/auth.js
@@ -28,14 +28,8 @@ const authorizeRequest = (req, { role }) => {
   return isAuthorized;
 };
 
-// Here we setup the security checks for the endpoints
-// that need it (in our case, only /protected). This
-// function will be called every time a request to a protected
-// endpoint is received
 const verifyToken = (req, token) => {
   let isValid = false;
-  // Validate the 'Authorization' header. it should have the following format:
-  // 'Bearer <tokenString>'
   if (token && token.indexOf('Bearer ') == 0) {
     const tokenString = token.split(' ')[1];
     const decodedToken = getTokenData(tokenString);

--- a/api/helpers/auth.js
+++ b/api/helpers/auth.js
@@ -2,7 +2,7 @@ const jwt = require('jsonwebtoken');
 const { google } = require('googleapis');
 const config = require('../../config');
 
-const { secret: jwtSecret, issuer } = config.jwt;
+const { secret: jwtSecret, issuer, expiresIn: jwtExpiresIn } = config.jwt;
 
 const getTokenData = (token) => {
   let data = null;
@@ -50,7 +50,7 @@ const verifyToken = (req, token) => {
 };
 
 const issueToken = ({ email, id }) => {
-  return jwt.sign({ email, id, issuer }, jwtSecret);
+  return jwt.sign({ email, id, issuer }, jwtSecret, { expiresIn: jwtExpiresIn });
 };
 
 const getAuthDataFromReq = (req) => {

--- a/config/constants.js
+++ b/config/constants.js
@@ -1,5 +1,7 @@
 const JWT_DEFAULT_ISSUER = 'cboard.io';
+const JWT_DEFAULT_EXPIRES_IN = '30d';
 
 module.exports = {
-  JWT_DEFAULT_ISSUER
+  JWT_DEFAULT_ISSUER,
+  JWT_DEFAULT_EXPIRES_IN
 };

--- a/config/env/development.js
+++ b/config/env/development.js
@@ -10,7 +10,8 @@ module.exports = {
   },
   jwt: {
     secret: process.env.JWT_SECRET,
-    issuer: process.env.JWT_ISSUER || constants.JWT_DEFAULT_ISSUER
+    issuer: process.env.JWT_ISSUER || constants.JWT_DEFAULT_ISSUER,
+    expiresIn: process.env.JWT_EXPIRES_IN || constants.JWT_DEFAULT_EXPIRES_IN
   },
   facebook: {
     APP_ID: process.env.FACEBOOK_APP_ID,

--- a/config/env/production.js
+++ b/config/env/production.js
@@ -11,7 +11,8 @@ module.exports = {
   },
   jwt: {
     secret: process.env.JWT_SECRET,
-    issuer: process.env.JWT_ISSUER || constants.JWT_DEFAULT_ISSUER
+    issuer: process.env.JWT_ISSUER || constants.JWT_DEFAULT_ISSUER,
+    expiresIn: process.env.JWT_EXPIRES_IN || constants.JWT_DEFAULT_EXPIRES_IN
   },
   facebook: {
     APP_ID: process.env.FACEBOOK_APP_ID,


### PR DESCRIPTION
Introduces an option to specify the expiration time for issued JSON Web Tokens (JWTs). This enhances security by ensuring authentication tokens are valid only for a defined duration.

- Configures JWTs to expire, by default, after 30 days.
- Allows the expiration period to be customized via the `JWT_EXPIRES_IN` environment variable.
- Removes verbose, outdated comments from authentication helper files for clarity.