### PR TITLE
Escape user input for regular expression queries

### DIFF
--- a/api/helpers/query.js
+++ b/api/helpers/query.js
@@ -3,8 +3,16 @@ module.exports = {
   getORQuery: getORQuery
 };
 
+// Escape regex metacharacters so user-supplied search values are matched
+// literally. This prevents regex injection and ReDoS via crafted patterns.
+function escapeRegExp(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 function getQuery(property, value, regex = false) {
-  const queryValue = regex ? { $regex: new RegExp(value, 'ig') } : value;
+  const queryValue = regex
+    ? { $regex: new RegExp(escapeRegExp(value), 'ig') }
+    : value;
 
   return { [property]: queryValue };
 }

--- a/test/controllers/board.js
+++ b/test/controllers/board.js
@@ -495,4 +495,27 @@ describe('Board API calls', function () {
       res.body.data.should.have.lengthOf(0);
     });
   });
+
+  describe('GET /board/public search (regex escaping)', function () {
+    it('it should treat regex special characters literally without erroring', async function () {
+      // `(` is an invalid regex on its own and crashed the unescaped query.
+      const res = await request(server)
+        .get(`/board/public?search=${encodeURIComponent('(')}`)
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200);
+
+      helper.verifyListProperties(res.body);
+    });
+
+    it('it should handle ReDoS-style patterns without erroring', async function () {
+      const res = await request(server)
+        .get(`/board/public?search=${encodeURIComponent('(a+)+$')}`)
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200);
+
+      helper.verifyListProperties(res.body);
+    });
+  });
 });

--- a/test/postman/cboard-api.postman_collection.json
+++ b/test/postman/cboard-api.postman_collection.json
@@ -1128,6 +1128,57 @@
       "response": []
     },
     {
+      "name": "/board/public?search regex escaping",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Status code is 200\", function () {",
+              "    pm.response.to.have.status(200);",
+              "});",
+              "pm.test(\"Malicious regex input is handled, not a server error\", function () {",
+              "    var jsonData = pm.response.json();",
+              "    pm.expect(jsonData).to.have.property('data');",
+              "    pm.expect(jsonData.data).to.be.an('array');",
+              "});"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          },
+          {
+            "key": "Authorization",
+            "value": "Bearer {{token}}"
+          }
+        ],
+        "url": {
+          "raw": "{{url}}/board/public?search=(",
+          "host": [
+            "{{url}}"
+          ],
+          "path": [
+            "board",
+            "public"
+          ],
+          "query": [
+            {
+              "key": "search",
+              "value": "("
+            }
+          ]
+        }
+      },
+      "response": []
+    },
+    {
       "name": "/board/report/",
       "event": [
         {


### PR DESCRIPTION
Properly escape metacharacters in user-supplied search values to prevent regex injection and ReDoS vulnerabilities via crafted patterns.
