### PR TITLE
Secure forgot password response details

### DIFF
--- a/api/controllers/user.js
+++ b/api/controllers/user.js
@@ -650,10 +650,12 @@ async function forgotPassword(req, res) {
           } else {
             const response = {
               success: 1,
-              userid: user.id,
-              url: token,
               message: 'Success! Check your mail to reset your password.'
             };
+            if (config.env !== 'production') {
+              response.userid = user.id;
+              response.url = token;
+            }
             return res.status(200).json(response);
           }
         });

--- a/test/controllers/user.js
+++ b/test/controllers/user.js
@@ -9,6 +9,7 @@ const uuid = require('uuid');
 const helper = require('../helper');
 
 const User = require('../../api/models/User');
+const config = require('../../config');
 
 //Parent block
 describe('User API calls', function () {
@@ -323,6 +324,31 @@ describe('User API calls', function () {
       userAndUrl.should.be
         .a('object')
         .with.all.keys('success', 'userid', 'url', 'message');
+    });
+
+    it('it should NOT return the reset token in production', async function () {
+      const userEmail = helper.generateEmail();
+      await helper.prepareUser(server, {
+        role: 'user',
+        email: userEmail,
+      });
+
+      const originalEnv = config.env;
+      config.env = 'production';
+      try {
+        const res = await request(server)
+          .post('/user/forgot')
+          .set('Accept', 'application/json')
+          .expect('Content-Type', /json/)
+          .send({ email: userEmail })
+          .expect(200);
+
+        res.body.should.be.a('object').with.all.keys('success', 'message');
+        res.body.should.not.have.property('url');
+        res.body.should.not.have.property('userid');
+      } finally {
+        config.env = originalEnv;
+      }
     });
   });
 

--- a/test/postman/cboard-api.postman_collection.json
+++ b/test/postman/cboard-api.postman_collection.json
@@ -1791,8 +1791,12 @@
               "pm.test(\"Status code is 200\", function () {",
               "    pm.response.to.have.status(200);",
               "});",
-              "pm.globals.set(\"reset_url\",pm.response.json().url);",
-              "console.log(pm.globals.get(\"reset_url\"));"
+              "pm.test(\"Reset token is not exposed in the response\", function () {",
+              "    var jsonData = pm.response.json();",
+              "    pm.expect(jsonData).to.not.have.property('url');",
+              "    pm.expect(jsonData).to.not.have.property('userid');",
+              "    pm.expect(jsonData).to.have.property('message');",
+              "});"
             ],
             "type": "text/javascript"
           }


### PR DESCRIPTION
Prevent password reset `userid` and `url` from being included in the API response when running in a production environment. This enhances security by avoiding exposure of sensitive information, while maintaining convenience for developers in non-production environments.
