### PR TITLE
Create PAYPAL_STATUS_MAP to cover all PayPal status

### DIFF
--- a/api/controllers/subscriber.js
+++ b/api/controllers/subscriber.js
@@ -157,10 +157,15 @@ async function getSubscriber(req, res) {
         remoteData = await paypal.getSubscriptionDetails(subscriber.transaction.subscriptionId);
         status = remoteData.status;
         // Normalize PayPal statuses to internal vocabulary
-        if (status.toLowerCase() === 'cancelled') status = 'canceled';
-        // PayPal suspends after exhausting payment retries; keep as 'suspended'
-        // so the frontend can show a targeted "fix payment on PayPal" CTA
-        if (status.toLowerCase() === 'suspended') status = 'suspended';
+        const PAYPAL_STATUS_MAP = {
+          approval_pending: 'proccesing',
+          approved: 'proccesing',
+          active: 'active',
+          suspended: 'suspended',
+          cancelled: 'canceled',
+          expired: 'expired'
+        };
+        status = PAYPAL_STATUS_MAP[status.toLowerCase()] || status.toLowerCase();
         // PayPal keeps ACTIVE during the billing retry window but accrues
         // outstanding_balance. Surface that as in_grace_period so the user
         // is warned without losing access.


### PR DESCRIPTION
Normalize all PayPal subscription statuses to internal vocabulary in `getSubscriber`. Replaces the previous ad-hoc `if` chain with a `PAYPAL_STATUS_MAP` lookup that covers the full PayPal status set: 

APPROVAL_PENDING and APPROVED → proccesing
ACTIVE → active
SUSPENDED → suspended
CANCELLED → canceled, EXPIRED → expired

Unknown statuses fall back to lowercase rather than being stored as raw uppercase strings.