### PR TITLE
Subscriber status refactor

### DIFF
--- a/api/controllers/subscriber.js
+++ b/api/controllers/subscriber.js
@@ -15,6 +15,10 @@ const {
   verifyAppStorePurchase,
   setSubscriptionState
 } = require('../helpers/appStore');
+const {
+  normalizeSubscriptionStatus,
+  PAYPAL_STATUS_MAP
+} = require('../helpers/subscriptionStatus');
 
 module.exports = {
   createSubscriber,
@@ -137,7 +141,14 @@ async function getSubscriber(req, res) {
     if (subscriber.transaction?.platform === 'android-playstore' &&
       subscriber.transaction?.nativePurchase?.purchaseToken) {
       try {
-        const newSubscriber = await subscriber.save();
+        let newSubscriber = await subscriber.save();
+        const normalizedStatus = normalizeSubscriptionStatus(
+          newSubscriber.transaction?.subscriptionState
+        );
+        if (newSubscriber.status !== normalizedStatus) {
+          newSubscriber.status = normalizedStatus;
+          newSubscriber = await newSubscriber.save();
+        }
         return res.status(200).json({success: true, ...newSubscriber.toJSON()});
       }
       catch (err) {
@@ -155,19 +166,16 @@ async function getSubscriber(req, res) {
       try {
         // get subscription from paypal API
         remoteData = await paypal.getSubscriptionDetails(subscriber.transaction.subscriptionId);
-        status = remoteData.status;
         // Normalize PayPal statuses to internal vocabulary
-        if (status.toLowerCase() === 'cancelled') status = 'canceled';
-        // PayPal suspends after exhausting payment retries; keep as 'suspended'
-        // so the frontend can show a targeted "fix payment on PayPal" CTA
-        if (status.toLowerCase() === 'suspended') status = 'suspended';
+        const rawStatus = remoteData.status?.toLowerCase();
+        status = PAYPAL_STATUS_MAP[rawStatus] || normalizeSubscriptionStatus(remoteData.status);
         // PayPal keeps ACTIVE during the billing retry window but accrues
         // outstanding_balance. Surface that as in_grace_period so the user
         // is warned without losing access.
         const outstandingBalance = parseFloat(
           remoteData.billing_info?.outstanding_balance?.value || 0
         );
-        if (status.toLowerCase() === 'active' && outstandingBalance > 0) {
+        if (status === 'active' && outstandingBalance > 0) {
           status = 'in_grace_period';
         }
         expiryDate = remoteData.billing_info?.next_billing_time;
@@ -202,7 +210,7 @@ async function getSubscriber(req, res) {
           ...subscriber.transaction,
           ...decodedTransaction
         };
-        subscriber.status = subscriber.transaction.subscriptionState;
+        subscriber.status = normalizeSubscriptionStatus(subscriber.transaction.subscriptionState);
       } catch (err) {
         return res.status(200).json({
           ok: false,

--- a/api/helpers/subscriptionStatus.js
+++ b/api/helpers/subscriptionStatus.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const KNOWN_STATUSES = [
+  'not_subscribed',
+  'proccesing',
+  'active',
+  'canceled',
+  'in_grace_period',
+  'paused',
+  'expired',
+  'on_hold',
+  'suspended',
+  'unverified'
+];
+
+const ANDROID_PREFIX = 'SUBSCRIPTION_STATE_';
+
+/**
+ * Normalize a raw platform subscription state string
+ * into the internal Cboard status vocabulary.
+ *
+ * Handles:
+ *   - Android raw constants: "SUBSCRIPTION_STATE_ACTIVE" -> "active"
+ *   - Already-normalized strings: "active" -> "active"
+ *   - Unknown values: falls back to "not_subscribed"
+ */
+function normalizeSubscriptionStatus(raw) {
+  if (!raw || typeof raw !== 'string') return 'not_subscribed';
+
+  let normalized = raw;
+
+  if (normalized.startsWith(ANDROID_PREFIX)) {
+    normalized = normalized.replace(ANDROID_PREFIX, '');
+  }
+
+  normalized = normalized.toLowerCase();
+
+  return KNOWN_STATUSES.includes(normalized) ? normalized : 'not_subscribed';
+}
+
+// Maps raw PayPal subscription statuses to the internal Cboard status vocabulary.
+// https://developer.paypal.com/docs/api/subscriptions/v1/#definition-subscription_status
+const PAYPAL_STATUS_MAP = {
+  approval_pending: 'proccesing',
+  approved: 'proccesing',
+  active: 'active',
+  suspended: 'suspended',
+  cancelled: 'canceled',
+  expired: 'expired'
+};
+
+module.exports = { normalizeSubscriptionStatus, PAYPAL_STATUS_MAP };

--- a/api/models/Subscribers.js
+++ b/api/models/Subscribers.js
@@ -184,18 +184,6 @@ subscribersSchema.path('transaction').validate(async function (transaction) {
   return true;
 }, 'transaction puchase token error');
 
-subscribersSchema.post('validate', async function (subscriber) {
-  //After refactor PayPal validation, change subscriber.status on this stage.
-  if(subscriber?.transaction?.platform === 'android-playstore'){
-    const status = subscriber?.transaction?.subscriptionState || 'not_subscribed';
-    if (status) {
-      const regexpStatus = /SUBSCRIPTION_STATE_([A-Z_]+)/;
-      const match = status.match(regexpStatus);
-      subscriber.status = match ? match[1] : status;
-    }
-  }
-});
-
 subscribersSchema.statics = {
   getByUserId: async function (userId) {
     let subscriber = null;


### PR DESCRIPTION
The `subscriber.status` and `transaction.subscriptionState` were two separate, inconsistently-written sources of truth for a user's subscription status. Android normalized status inside a hidden Mongoose `post('validate')` hook on the model; iOS and PayPal each did their own ad-hoc normalization directly in the controller, with PayPal in particular leaving some raw values (like `ACTIVE`, `APPROVAL_PENDING`) unnormalized.

This PR makes `getSubscriber` the single place that derives `subscriber.status`, using a shared normalization helper across all three platforms.
- Add `api/helpers/subscriptionStatus.js`: `normalizeSubscriptionStatus()` maps raw platform states (including Android's `SUBSCRIPTION_STATE_*` constants) into Cboard's internal status vocabulary, falling back to `not_subscribed` for anything unrecognized. `PAYPAL_STATUS_MAP` maps PayPal's raw subscription statuses (including `approval_pending`/`approved` → `proccesing`, previously left as raw uppercase strings).
- Remove the `post('validate')` hook from `api/models/Subscribers.js` — the model layer no longer derives business status, only validates shape.
- `api/controllers/subscriber.js`: Android, iOS, and PayPal branches of `getSubscriber` now all route through the shared helper. The Android branch normalizes after `save()` resolves and only issues a second `save()` when the computed status actually changes.

## Test plan
- `npm test` — full suite passes (150 passing; the 1 pre-existing failure in `Access API calls` is unrelated to this change)
- Manual check against a local dev db with mocked Google Play responses for `active`, `expired`, and `in_grace_period` states
- Verified the Android branch's conditional second `save()` does not trigger a duplicate Google Play API call